### PR TITLE
Add loading spinner and autocomplete

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -21,9 +21,10 @@ import { useUser } from '@/contexts/UserContext'
 import CreateAppointmentModal from '@/components/CreateAppointmentModal'
 import AppointmentDetailsPopup from '@/components/AppointmentDetailsPopup'
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import PatientAutocomplete from '@/components/PatientAutocomplete'
 import type { Patient, Appointment } from '@/types/db'
 import { toast } from 'sonner'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 const locales = { es }
 const localizer = dateFnsLocalizer({
@@ -47,7 +48,7 @@ export default function DashboardCalendar() {
   const [view, setView] = useState<View | null>(null)
   const [date, setDate] = useState(new Date())
   const [patients, setPatients] = useState<Patient[]>([])
-  const [patientFilter, setPatientFilter] = useState('')
+  const [patientFilter, setPatientFilter] = useState('all')
   type CalendarEvent = {
     start: Date
     end: Date
@@ -122,7 +123,12 @@ export default function DashboardCalendar() {
   const todayStr = format(date, "EEEE, d 'de' MMMM yyyy", { locale: es })
   const title = todayStr.charAt(0).toUpperCase() + todayStr.slice(1)
 
-  if (!view) return null
+  if (!view)
+    return (
+      <div className="p-4 flex justify-center">
+        <LoadingSpinner className="h-6 w-6" />
+      </div>
+    )
 
   return (
     <Wrapper>
@@ -137,19 +143,11 @@ export default function DashboardCalendar() {
           </IconButton>
         </div>
         <div className="flex items-center gap-2 ml-auto">
-          <Select value={patientFilter} onValueChange={setPatientFilter}>
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Todos" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos</SelectItem>
-              {patients.map((p) => (
-                <SelectItem key={p.patientId} value={p.patientId}>
-                  {p.firstName} {p.lastName}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <PatientAutocomplete
+            patients={patients}
+            value={patientFilter}
+            onChange={(v) => setPatientFilter(v || 'all')}
+          />
           <button
             className="bg-primary text-white px-3 py-1 rounded flex items-center gap-1"
             onClick={() => setOpen(true)}

--- a/src/app/(protected)/patients/[id]/page.tsx
+++ b/src/app/(protected)/patients/[id]/page.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import tw from 'tailwind-styled-components'
 import { format } from 'date-fns'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 export default function PatientDetailsPage() {
   const params = useParams<{ id: string }>()
@@ -59,7 +60,12 @@ export default function PatientDetailsPage() {
         .catch(() => {})
   }, [params.id, tenant])
 
-  if (!patient) return <div className="p-2">Cargando...</div>
+  if (!patient)
+    return (
+      <div className="p-2 flex justify-center">
+        <LoadingSpinner className="h-6 w-6" />
+      </div>
+    )
 
   const past = appointments.filter(
     (a) => new Date(a.scheduledStart) < new Date(),
@@ -100,8 +106,15 @@ export default function PatientDetailsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {future.map((a) => (
-                  <TableRow key={a.appointmentId}>
+                {future.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="py-4 text-center">
+                      No hay citas futuras
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  future.map((a) => (
+                    <TableRow key={a.appointmentId}>
                     <TableCell>
                       {format(new Date(a.scheduledStart), 'dd/MM/yyyy')}
                     </TableCell>
@@ -121,7 +134,8 @@ export default function PatientDetailsPage() {
                       </button>
                     </TableCell>
                   </TableRow>
-                ))}
+                  ))
+                )}
               </TableBody>
           </Table>
         </Section>
@@ -137,8 +151,15 @@ export default function PatientDetailsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {past.map((a) => (
-                <TableRow key={a.appointmentId}>
+              {past.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="py-4 text-center">
+                    No hay citas pasadas
+                  </TableCell>
+                </TableRow>
+              ) : (
+                past.map((a) => (
+                  <TableRow key={a.appointmentId}>
                   <TableCell>
                     {format(new Date(a.scheduledStart), 'dd/MM/yyyy')}
                   </TableCell>
@@ -158,7 +179,8 @@ export default function PatientDetailsPage() {
                     </button>
                   </TableCell>
                 </TableRow>
-              ))}
+                ))
+              )}
             </TableBody>
           </Table>
         </Section>
@@ -177,8 +199,15 @@ export default function PatientDetailsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {records.map((r) => (
-                <TableRow key={r.recordId}>
+              {records.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={2} className="py-4 text-center">
+                    No hay registros
+                  </TableCell>
+                </TableRow>
+              ) : (
+                records.map((r) => (
+                  <TableRow key={r.recordId}>
                     <TableCell>{r.summary}</TableCell>
                     <TableCell className="flex gap-2">
                       <button onClick={() => { setEditingRecord(r); setOpenRecord(true); }}>
@@ -193,9 +222,10 @@ export default function PatientDetailsPage() {
                         <Trash size={16} />
                       </button>
                     </TableCell>
-                </TableRow>
-              ))}
-              </TableBody>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
             </Table>
           </Section>
         </div>

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -10,17 +10,23 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Plus } from 'lucide-react'
 import CreatePatientModal from '@/components/CreatePatientModal'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 export default function PatientsPage() {
   const { tenant } = useUser()
   const [patients, setPatients] = useState<Patient[]>([])
+  const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [open, setOpen] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
     if (!tenant) return
-    getPatients(tenant.tenantId).then(setPatients).catch(() => {})
+    setLoading(true)
+    getPatients(tenant.tenantId)
+      .then(setPatients)
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }, [tenant])
 
   const filtered = patients.filter((p) =>
@@ -53,22 +59,36 @@ export default function PatientsPage() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {filtered.map((p) => (
-            <TableRow
-              key={p.patientId}
-              className="cursor-pointer hover:bg-muted"
-              onClick={() => router.push(`/patients/${p.patientId}`)}
-            >
-              <TableCell>
-                {p.firstName} {p.lastName}
-              </TableCell>
-              <TableCell>{p.email}</TableCell>
-              <TableCell>{p.phone}</TableCell>
-              <TableCell>
-                <Link className="text-primary" href={`/patients/${p.patientId}`}>Ver</Link>
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={4} className="py-6 text-center">
+                <LoadingSpinner className="h-6 w-6 mx-auto" />
               </TableCell>
             </TableRow>
-          ))}
+          ) : filtered.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={4} className="py-6 text-center">
+                No se encontraron pacientes
+              </TableCell>
+            </TableRow>
+          ) : (
+            filtered.map((p) => (
+              <TableRow
+                key={p.patientId}
+                className="cursor-pointer hover:bg-muted"
+                onClick={() => router.push(`/patients/${p.patientId}`)}
+              >
+                <TableCell>
+                  {p.firstName} {p.lastName}
+                </TableCell>
+                <TableCell>{p.email}</TableCell>
+                <TableCell>{p.phone}</TableCell>
+                <TableCell>
+                  <Link className="text-primary" href={`/patients/${p.patientId}`}>Ver</Link>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
         </TableBody>
       </Table>
       <CreatePatientModal

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { toast } from 'sonner'
+import LoadingSpinner from './LoadingSpinner'
 import { signUp } from '@/db/db'
 import tw from 'tailwind-styled-components'
 import Link from 'next/link'
@@ -44,13 +45,7 @@ export default function AuthForm({ mode }: AuthFormProps) {
   }
 
   const title = mode === 'signup' ? 'Crear cuenta' : 'Iniciar sesión'
-  const actionLabel = loading
-    ? mode === 'signup'
-      ? 'Creando...'
-      : 'Ingresando...'
-    : mode === 'signup'
-      ? 'Crear cuenta'
-      : 'Ingresar'
+  const actionLabel = mode === 'signup' ? 'Crear cuenta' : 'Ingresar'
 
   return (
     <Wrapper>
@@ -130,8 +125,8 @@ export default function AuthForm({ mode }: AuthFormProps) {
               disabled={loading}
             />
           </FieldGroup>
-          <Button onClick={handleAuth} disabled={loading} className="w-full">
-            {actionLabel}
+          <Button onClick={handleAuth} disabled={loading} className="w-full flex items-center justify-center gap-1">
+            {loading ? <LoadingSpinner className="h-4 w-4" /> : actionLabel}
           </Button>
           <div className="text-sm text-center">
             {mode === 'signup' ? (

--- a/src/components/CreateAppointmentModal.tsx
+++ b/src/components/CreateAppointmentModal.tsx
@@ -20,6 +20,7 @@ import { Select, SelectItem, SelectTrigger, SelectContent, SelectValue } from '@
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import LoadingSpinner from './LoadingSpinner'
 
 const schema = z.object({
   patientId: z.string().nonempty('Seleccione paciente'),
@@ -253,11 +254,15 @@ export default function CreateAppointmentModal({
               )}
             />
             <Button type="submit" disabled={loading} className="w-full flex items-center justify-center gap-1">
-              {loading
-                ? 'Guardando...'
-                : appointment
-                ? 'Guardar'
-                : <>Crear <Plus size={16} /></>}
+              {loading ? (
+                <LoadingSpinner className="h-4 w-4" />
+              ) : appointment ? (
+                'Guardar'
+              ) : (
+                <>
+                  Crear <Plus size={16} />
+                </>
+              )}
             </Button>
           </form>
         </Form>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,14 @@
+"use client"
+import { cn } from "@/lib/utils"
+
+export default function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "animate-spin rounded-full border-2 border-primary border-t-transparent",
+        "h-5 w-5",
+        className,
+      )}
+    />
+  )
+}

--- a/src/components/NotificationBellPopover.tsx
+++ b/src/components/NotificationBellPopover.tsx
@@ -6,6 +6,7 @@ import { useUser } from '@/contexts/UserContext'
 import { toast } from 'sonner'
 import tw from 'tailwind-styled-components'
 import { Notification } from '@/types/db'
+import LoadingSpinner from './LoadingSpinner'
 
 export default function NotificationBellPopover() {
   const { user } = useUser()
@@ -46,7 +47,9 @@ export default function NotificationBellPopover() {
       {open && (
         <Popover>
           {loading ? (
-            <div className="p-2 text-sm">Cargando...</div>
+            <div className="p-2 flex justify-center">
+              <LoadingSpinner className="h-4 w-4" />
+            </div>
           ) : notifications.length === 0 ? (
             <div className="p-2 text-sm">Sin notificaciones</div>
           ) : (

--- a/src/components/PatientAutocomplete.tsx
+++ b/src/components/PatientAutocomplete.tsx
@@ -1,0 +1,86 @@
+"use client"
+import { useState, useEffect, useRef } from 'react'
+import { Input } from '@/components/ui/input'
+import type { Patient } from '@/types/db'
+
+type Props = {
+  patients: Patient[]
+  value: string
+  onChange: (v: string) => void
+}
+
+export default function PatientAutocomplete({ patients, value, onChange }: Props) {
+  const [term, setTerm] = useState('')
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  useEffect(() => {
+    if (value === 'all') setTerm('')
+  }, [value])
+
+  const filtered = term
+    ? patients.filter((p) =>
+        `${p.firstName} ${p.lastName}`
+          .toLowerCase()
+          .includes(term.toLowerCase()),
+      )
+    : patients
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Input
+        placeholder="Todos"
+        value={term}
+        onChange={(e) => {
+          setTerm(e.target.value)
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        className="w-40"
+      />
+      {open && (
+        <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-y-auto rounded-md border bg-white shadow">
+          {term === '' && (
+            <li
+              className="cursor-pointer px-2 py-1 hover:bg-muted"
+              onMouseDown={() => {
+                onChange('all')
+                setTerm('')
+                setOpen(false)
+              }}
+            >
+              Todos
+            </li>
+          )}
+          {filtered.length === 0 ? (
+            <li className="px-2 py-1 text-muted-foreground select-none">
+              Paciente no encontrado
+            </li>
+          ) : (
+            filtered.map((p) => (
+              <li
+                key={p.patientId}
+                className="cursor-pointer px-2 py-1 hover:bg-muted"
+                onMouseDown={() => {
+                  onChange(p.patientId)
+                  setTerm(`${p.firstName} ${p.lastName}`)
+                  setOpen(false)
+                }}
+              >
+                {p.firstName} {p.lastName}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `LoadingSpinner` component for consistent feedback
- add `PatientAutocomplete` component
- show spinner while verifying user auth and while saving forms
- indicate empty states for patient lists, appointments and medical records
- add patient filter autocomplete in the calendar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685650a248508333a4100be1d4ecee4b