### PR TITLE
UI glass style

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,71 +45,71 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.129 0.042 264.695);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.129 0.042 264.695);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: #3abdd4;
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.968 0.007 247.896);
+  --background: #f8fafc;
+  --foreground: #0f172a;
+  --card: rgba(255,255,255,0.6);
+  --card-foreground: #0f172a;
+  --popover: rgba(255,255,255,0.6);
+  --popover-foreground: #0f172a;
+  --primary: #0ea5e9;
+  --primary-foreground: white;
+  --secondary: rgba(255,255,255,0.6);
+  --secondary-foreground: #0f172a;
+  --muted: rgba(255,255,255,0.4);
   --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.929 0.013 255.508);
-  --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.704 0.04 256.788);
+  --accent: rgba(255,255,255,0.6);
+  --accent-foreground: #0f172a;
+  --destructive: #ef4444;
+  --border: rgba(255,255,255,0.3);
+  --input: rgba(255,255,255,0.5);
+  --ring: #7dd3fc;
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.129 0.042 264.695);
-  --sidebar-primary: oklch(0.208 0.042 265.755);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.968 0.007 247.896);
-  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.929 0.013 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --sidebar: rgba(255,255,255,0.6);
+  --sidebar-foreground: #0f172a;
+  --sidebar-primary: #0284c7;
+  --sidebar-primary-foreground: white;
+  --sidebar-accent: rgba(255,255,255,0.4);
+  --sidebar-accent-foreground: #0f172a;
+  --sidebar-border: rgba(255,255,255,0.3);
+  --sidebar-ring: #7dd3fc;
 }
 
 .dark {
-  --background: oklch(0.129 0.042 264.695);
-  --foreground: oklch(0.984 0.003 247.858);
-  --card: oklch(0.208 0.042 265.755);
-  --card-foreground: oklch(0.984 0.003 247.858);
-  --popover: oklch(0.208 0.042 265.755);
-  --popover-foreground: oklch(0.984 0.003 247.858);
-  --primary: oklch(0.929 0.013 255.508);
-  --primary-foreground: oklch(0.208 0.042 265.755);
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
-  --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.551 0.027 264.364);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.208 0.042 265.755);
-  --sidebar-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
-  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --card: rgba(30,41,59,0.6);
+  --card-foreground: #f8fafc;
+  --popover: rgba(30,41,59,0.6);
+  --popover-foreground: #f8fafc;
+  --primary: #38bdf8;
+  --primary-foreground: #0f172a;
+  --secondary: rgba(30,41,59,0.6);
+  --secondary-foreground: #f8fafc;
+  --muted: rgba(30,41,59,0.4);
+  --muted-foreground: #cbd5e1;
+  --accent: rgba(30,41,59,0.6);
+  --accent-foreground: #f8fafc;
+  --destructive: #ef4444;
+  --border: rgba(255,255,255,0.1);
+  --input: rgba(255,255,255,0.1);
+  --ring: #7dd3fc;
+  --chart-1: #4c1d95;
+  --chart-2: #0ea5e9;
+  --chart-3: #7e22ce;
+  --chart-4: #047857;
+  --chart-5: #a16207;
+  --sidebar: rgba(30,41,59,0.6);
+  --sidebar-foreground: #f8fafc;
+  --sidebar-primary: #0ea5e9;
+  --sidebar-primary-foreground: #f8fafc;
+  --sidebar-accent: rgba(30,41,59,0.4);
+  --sidebar-accent-foreground: #f8fafc;
+  --sidebar-border: rgba(255,255,255,0.1);
+  --sidebar-ring: #7dd3fc;
 }
 
 @layer base {
@@ -117,7 +117,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-gradient-to-tr from-sky-50 via-slate-100 to-white dark:from-slate-900 dark:via-slate-950 dark:to-black text-foreground;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
         <UserProvider>
           {children}

--- a/src/components/AuthScreenLayout.tsx
+++ b/src/components/AuthScreenLayout.tsx
@@ -47,7 +47,7 @@ export default function AuthScreenLayout({ children }: Props) {
 // Styled components
 export const Background = tw.div`
   relative min-h-screen w-full flex items-center justify-center overflow-hidden
-  bg-gradient-to-tr from-[#0589c2] via-[#3abdd4] to-[#93efff] animate-gradient
+  bg-gradient-to-tr from-sky-200 via-blue-200 to-cyan-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-700 animate-gradient
 `
 
 export const BouncingLogo = tw(Image)`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -72,9 +72,9 @@ export default function Sidebar() {
 
 // styled components
 const Wrapper = tw.div<{ $collapsed: boolean }>`
-  relative h-full flex flex-col justify-between  transition-all
+  relative h-full flex flex-col justify-between transition-all
   ${({ $collapsed }) => ($collapsed ? 'w-16 p-2' : 'w-64 p-3')}
-  border-r border-sidebar-border bg-sidebar text-sidebar-foreground
+  border-r border-sidebar-border bg-sidebar/60 backdrop-blur-lg text-sidebar-foreground
 `
 
 const TopSection = tw.div`flex flex-col gap-8`
@@ -86,19 +86,19 @@ const Logo = tw(Image)`shrink-0`
 const CollapsedLogoWrapper = tw.div`flex justify-center p-2`
 
 const ToggleButton = tw.button`
-  p-1 rounded hover:bg-muted text-muted-foreground
+  p-1 rounded-full hover:bg-white/30 dark:hover:bg-slate-700/30 text-muted-foreground backdrop-blur-md
 `
 
 const ToggleFloating = tw.button`
   absolute right-[-26.5px] top-8 -translate-y-1/2
-  bg-sidebar border-r border-b border-t border-border rounded-r-md
-  p-1 hover:bg-muted text-muted-foreground
+  bg-sidebar/60 border-r border-b border-t border-border rounded-r-lg backdrop-blur-lg
+  p-1 hover:bg-white/30 dark:hover:bg-slate-700/30 text-muted-foreground
   transition-all
 `
 
 const NavList = tw.div`flex flex-col gap-1`
 
 const NavItem = tw.div<{ $active?: boolean; $collapsed?: boolean }>`
-  ${({ $active }) => ($active ? 'bg-primary text-white font-medium' : 'text-muted-foreground hover:bg-muted')}
-  rounded-lg transition-colors hover:text-foreground
+  ${({ $active }) => ($active ? 'bg-primary/70 text-white font-medium' : 'text-muted-foreground hover:bg-white/30 dark:hover:bg-slate-700/30')}
+  rounded-full transition-colors hover:text-foreground backdrop-blur-md
 `

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,26 +5,26 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive backdrop-blur-md",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-primary/80 text-primary-foreground shadow-md hover:bg-primary/60",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-white/40 dark:bg-slate-800/40 shadow-md backdrop-blur-md hover:bg-white/60 dark:hover:bg-slate-800/60 text-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-md hover:bg-secondary",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-white/30 dark:hover:bg-slate-700/30",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 rounded-full gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-full px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
     },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-white/60 dark:bg-slate-800/60 backdrop-blur-md text-card-foreground flex flex-col gap-6 rounded-xl border border-white/40 dark:border-slate-700/60 py-6 shadow-lg",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-slate-700/40 bg-white/40 backdrop-blur-md border-input flex h-9 w-full min-w-0 rounded-full border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,12 +9,16 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#3abdd4',
-        danger: '#ff3564',
+        primary: '#0ea5e9',
+        danger: '#ef4444',
+        accent: '#38bdf8',
         secondary: {
-          DEFAULT: '#f9f9f9',
-          dark: '#1a1a1a',
+          DEFAULT: 'rgba(255,255,255,0.6)',
+          dark: 'rgba(30,41,59,0.6)',
         },
+      },
+      borderRadius: {
+        xl: '1rem',
       },
     },
   },


### PR DESCRIPTION
## Summary
- adopt a lighter glassmorphism theme
- re-style Card, Button and Input components
- add blurred translucent sidebar and auth background
- tweak layout and global styles

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68565393de5c833391c4e0f9d011fd63