### PR TITLE
UI glass redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,21 +44,22 @@
 }
 
 :root {
-  --radius: 0.625rem;
+  /* larger radius for softer, rounded corners */
+  --radius: 1rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.129 0.042 264.695);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.129 0.042 264.695);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: #3abdd4;
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.968 0.007 247.896);
+  --primary: #0a84ff;
+  --primary-foreground: #ffffff;
+  --secondary: rgba(255, 255, 255, 0.75);
+  --secondary-foreground: #0a0a0a;
+  --muted: rgba(255, 255, 255, 0.75);
   --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
+  --accent: rgba(255, 255, 255, 0.75);
+  --accent-foreground: #0a0a0a;
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.929 0.013 255.508);
   --input: oklch(0.929 0.013 255.508);
@@ -68,14 +69,14 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.129 0.042 264.695);
-  --sidebar-primary: oklch(0.208 0.042 265.755);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.968 0.007 247.896);
-  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.929 0.013 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --sidebar: rgba(255, 255, 255, 0.6);
+  --sidebar-foreground: #0a0a0a;
+  --sidebar-primary: #0a84ff;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(255, 255, 255, 0.6);
+  --sidebar-accent-foreground: #0a0a0a;
+  --sidebar-border: rgba(255, 255, 255, 0.4);
+  --sidebar-ring: rgba(0, 0, 0, 0.1);
 }
 
 .dark {
@@ -85,14 +86,14 @@
   --card-foreground: oklch(0.984 0.003 247.858);
   --popover: oklch(0.208 0.042 265.755);
   --popover-foreground: oklch(0.984 0.003 247.858);
-  --primary: oklch(0.929 0.013 255.508);
-  --primary-foreground: oklch(0.208 0.042 265.755);
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
+  --primary: #0a84ff;
+  --primary-foreground: #ffffff;
+  --secondary: rgba(29, 30, 32, 0.6);
+  --secondary-foreground: #ffffff;
+  --muted: rgba(29, 30, 32, 0.6);
   --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
+  --accent: rgba(29, 30, 32, 0.6);
+  --accent-foreground: #ffffff;
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
@@ -102,14 +103,14 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.208 0.042 265.755);
-  --sidebar-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
-  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
+  --sidebar: rgba(29, 30, 32, 0.5);
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #0a84ff;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(29, 30, 32, 0.5);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.1);
+  --sidebar-ring: rgba(255, 255, 255, 0.2);
 }
 
 @layer base {
@@ -134,6 +135,18 @@
 .animate-gradient {
   background-size: 200% 200%;
   animation: gradient 10s ease infinite;
+}
+
+/* frosted glass utility class */
+.glass {
+  backdrop-filter: blur(24px);
+  background-color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.dark .glass {
+  background-color: rgba(29, 30, 32, 0.6);
+  border-color: rgba(255, 255, 255, 0.1);
 }
 
 .rbc-month-view .rbc-today,

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -157,7 +157,7 @@ const Wrapper = tw.div`
 `
 
 const StyledCard = tw(Card)`
-  w-full max-w-lg
+  w-full max-w-lg glass shadow-lg backdrop-blur-xl
 `
 
 const FieldGroup = tw.div`
@@ -165,6 +165,6 @@ const FieldGroup = tw.div`
 `
 
 const Title = tw.h1`
-  text-6xl font-bold mb-6 text-center
-  text-white
+  text-6xl font-bold mb-6 text-center text-transparent bg-clip-text
+  bg-gradient-to-r from-primary to-purple-500 animate-gradient
 `;

--- a/src/components/AuthScreenLayout.tsx
+++ b/src/components/AuthScreenLayout.tsx
@@ -55,5 +55,5 @@ export const BouncingLogo = tw(Image)`
 `
 
 export const AuthFormWrapper = tw.div`
-  z-20 relative w-full
+  z-20 relative w-full glass shadow-lg p-6 rounded-2xl backdrop-blur-xl
 `

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -72,9 +72,9 @@ export default function Sidebar() {
 
 // styled components
 const Wrapper = tw.div<{ $collapsed: boolean }>`
-  relative h-full flex flex-col justify-between  transition-all
+  relative h-full flex flex-col justify-between transition-all
   ${({ $collapsed }) => ($collapsed ? 'w-16 p-2' : 'w-64 p-3')}
-  border-r border-sidebar-border bg-sidebar text-sidebar-foreground
+  glass shadow-md text-sidebar-foreground
 `
 
 const TopSection = tw.div`flex flex-col gap-8`
@@ -86,19 +86,17 @@ const Logo = tw(Image)`shrink-0`
 const CollapsedLogoWrapper = tw.div`flex justify-center p-2`
 
 const ToggleButton = tw.button`
-  p-1 rounded hover:bg-muted text-muted-foreground
+  p-1 rounded glass hover:bg-muted text-muted-foreground
 `
 
 const ToggleFloating = tw.button`
   absolute right-[-26.5px] top-8 -translate-y-1/2
-  bg-sidebar border-r border-b border-t border-border rounded-r-md
-  p-1 hover:bg-muted text-muted-foreground
-  transition-all
+  glass rounded-r-md p-1 hover:bg-muted transition-all text-muted-foreground
 `
 
 const NavList = tw.div`flex flex-col gap-1`
 
 const NavItem = tw.div<{ $active?: boolean; $collapsed?: boolean }>`
-  ${({ $active }) => ($active ? 'bg-primary text-white font-medium' : 'text-muted-foreground hover:bg-muted')}
+  ${({ $active }) => ($active ? 'glass bg-primary/20 text-primary font-medium' : 'text-muted-foreground hover:bg-muted/50')}
   rounded-lg transition-colors hover:text-foreground
 `


### PR DESCRIPTION
## Summary
- adopt transparent colors and large radius in globals
- add new `glass` class for frosted glass look
- style the sidebar with blur and glassy effects
- update auth screens with gradient titles and glass card styling

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font during build)*

------
https://chatgpt.com/codex/tasks/task_e_68565393de5c833391c4e0f9d011fd63