### PR TITLE
Fix appointment modal options and date picker

### DIFF
--- a/src/components/CreateAppointmentModal.tsx
+++ b/src/components/CreateAppointmentModal.tsx
@@ -16,7 +16,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Select, SelectItem, SelectTrigger, SelectContent, SelectValue } from '@/components/ui/select'
+import PatientAutocomplete from './PatientAutocomplete'
 import { DatePicker } from '@/components/ui/date-picker'
 import TimeSelect from '@/components/ui/time-select'
 import { Button } from '@/components/ui/button'
@@ -157,7 +157,7 @@ export default function CreateAppointmentModal({
     } catch (err) {
       console.error('Error computing times', err)
     }
-  }, [dateValue, tenant, occupied, appointment, form])
+  }, [dateValue, tenant, occupied, appointment, open])
 
   const submit = async (values: FormValues) => {
     setLoading(true)
@@ -241,18 +241,11 @@ export default function CreateAppointmentModal({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Paciente</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Seleccione" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {patients.map((p) => (
-                        <SelectItem key={p.patientId} value={p.patientId}>
-                          {p.firstName} {p.lastName}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <PatientAutocomplete
+                    patients={patients}
+                    value={field.value}
+                    onChange={(v) => field.onChange(v)}
+                  />
                   <FormMessage />
                 </FormItem>
               )}
@@ -280,6 +273,7 @@ export default function CreateAppointmentModal({
                       onChange={(d) =>
                         field.onChange(d ? d.toISOString().slice(0, 10) : '')
                       }
+                      disabled={{ before: new Date() }}
                     />
                     <FormMessage />
                   </FormItem>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -11,10 +11,12 @@ export function DatePicker({
   date,
   onChange,
   placeholder = "Fecha",
+  disabled,
 }: {
   date: Date | undefined
   onChange: (date: Date | undefined) => void
   placeholder?: string
+  disabled?: React.ComponentProps<typeof Calendar>["disabled"]
 }) {
   return (
     <Popover>
@@ -31,7 +33,13 @@ export function DatePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
-        <Calendar mode="single" selected={date} onSelect={onChange} initialFocus />
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={onChange}
+          initialFocus
+          disabled={disabled}
+        />
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
## Summary
- use PatientAutocomplete in appointment modal
- disable past dates in DatePicker
- recompute available hours when modal opens

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6859eb5f323083338d92f8bba65dc618