### PR TITLE
Add smarter appointment scheduling

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -57,6 +57,8 @@ export default function DashboardCalendar() {
   }
   const [events, setEvents] = useState<CalendarEvent[]>([])
   const [open, setOpen] = useState(false)
+  const [slotDate, setSlotDate] = useState<Date | null>(null)
+  const [slotStart, setSlotStart] = useState<Date | null>(null)
   const [selected, setSelected] = useState<{ appt: Appointment; name: string } | null>(null)
 
   const navigate = (step: number) => {
@@ -150,7 +152,11 @@ export default function DashboardCalendar() {
           />
           <button
             className="bg-primary text-white px-3 py-1 rounded flex items-center gap-1"
-            onClick={() => setOpen(true)}
+            onClick={() => {
+              setSlotDate(new Date())
+              setSlotStart(null)
+              setOpen(true)
+            }}
           >
             Nueva cita <Plus size={16} />
           </button>
@@ -181,6 +187,11 @@ export default function DashboardCalendar() {
             onSelectEvent={(e: CalendarEvent) =>
               setSelected({ appt: e.resource, name: e.title })
             }
+            onSelectSlot={(slot) => {
+              setSlotDate(slot.start)
+              setSlotStart(view === 'month' ? null : slot.start)
+              setOpen(true)
+            }}
             style={{ height: 'calc(100vh - 150px)' }}
             selectable
             components={{ toolbar: () => null }}
@@ -189,8 +200,14 @@ export default function DashboardCalendar() {
       </div>
       <CreateAppointmentModal
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={() => {
+          setOpen(false)
+          setSlotDate(null)
+          setSlotStart(null)
+        }}
         onCreated={() => loadEvents()}
+        initialDate={slotDate}
+        initialStart={slotStart}
       />
       <AppointmentDetailsPopup
         appointment={selected?.appt || null}

--- a/src/components/CreateAppointmentModal.tsx
+++ b/src/components/CreateAppointmentModal.tsx
@@ -4,7 +4,11 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useEffect, useState } from 'react'
 import { getPatients } from '@/db/patients'
-import { createAppointment, updateAppointment } from '@/db/appointments'
+import {
+  createAppointment,
+  updateAppointment,
+  getAppointmentsInRange,
+} from '@/db/appointments'
 import { useUser } from '@/contexts/UserContext'
 import type { Patient, Appointment } from '@/types/db'
 import { toast } from 'sonner'
@@ -16,22 +20,42 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Select, SelectItem, SelectTrigger, SelectContent, SelectValue } from '@/components/ui/select'
+import {
+  Select,
+  SelectItem,
+  SelectTrigger,
+  SelectContent,
+  SelectValue,
+} from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import LoadingSpinner from './LoadingSpinner'
+import { startOfDay, endOfDay, getDaysInMonth, format } from 'date-fns'
+import { getWorkingHoursForDate, generateTimeSlots } from '@/lib/scheduling'
 
 const schema = z.object({
   patientId: z.string().nonempty('Seleccione paciente'),
   providerId: z.string().nonempty('Doctor'),
-  date: z.string().nonempty('Fecha'),
-  time: z.string().nonempty('Hora'),
-  duration: z.string().nonempty('Duración'),
+  year: z.string().nonempty('Año'),
+  month: z.string().nonempty('Mes'),
+  day: z.string().nonempty('Día'),
+  startTime: z.string().nonempty('Hora'),
   notes: z.string().optional(),
 })
 
 type FormValues = z.infer<typeof schema>
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  onCreated?: (appt: Appointment) => void
+  patientId?: string
+  appointment?: Appointment | null
+  onUpdated?: (appt: Appointment) => void
+  initialDate?: Date | null
+  initialStart?: Date | null
+}
 
 export default function CreateAppointmentModal({
   open,
@@ -40,57 +64,55 @@ export default function CreateAppointmentModal({
   patientId,
   appointment,
   onUpdated,
-}: {
-  open: boolean
-  onClose: () => void
-  onCreated?: (appt: Appointment) => void
-  patientId?: string
-  appointment?: Appointment | null
-  onUpdated?: (appt: Appointment) => void
-}) {
+  initialDate,
+  initialStart,
+}: Props) {
   const { user, tenant } = useUser()
   const [patients, setPatients] = useState<Patient[]>([])
   const [loading, setLoading] = useState(false)
+  const [times, setTimes] = useState<string[]>([])
+  const currentYear = new Date().getFullYear().toString()
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
       patientId: appointment?.patientId ?? patientId ?? '',
       providerId: appointment?.providerId ?? '',
-      date: appointment
-        ? appointment.scheduledStart.slice(0, 10)
-        : '',
-      time: appointment
-        ? appointment.scheduledStart.slice(11, 16)
-        : '',
-      duration: appointment
-        ? (
-            (new Date(appointment.scheduledEnd).getTime() -
-              new Date(appointment.scheduledStart).getTime()) /
-            60000
-          ).toString()
-        : '',
+      year: currentYear,
+      month: '',
+      day: '',
+      startTime: '',
       notes: appointment?.reason ?? '',
     },
   })
 
+  const resetForm = () => {
+    const baseDate = appointment
+      ? new Date(appointment.scheduledStart)
+      : initialStart ?? initialDate ?? new Date()
+    const year = baseDate.getFullYear().toString()
+    const month = (baseDate.getMonth() + 1).toString().padStart(2, '0')
+    const day = baseDate.getDate().toString().padStart(2, '0')
+    const startTime = appointment
+      ? format(new Date(appointment.scheduledStart), 'HH:mm')
+      : initialStart
+        ? format(initialStart, 'HH:mm')
+        : ''
+    form.reset({
+      patientId: appointment?.patientId ?? patientId ?? '',
+      providerId: appointment?.providerId ?? '',
+      year,
+      month,
+      day,
+      startTime,
+      notes: appointment?.reason ?? '',
+    })
+  }
+
   useEffect(() => {
-    if (open)
-      form.reset({
-        patientId: appointment?.patientId ?? patientId ?? '',
-        providerId: appointment?.providerId ?? '',
-        date: appointment ? appointment.scheduledStart.slice(0, 10) : '',
-        time: appointment ? appointment.scheduledStart.slice(11, 16) : '',
-        duration: appointment
-          ? (
-              (new Date(appointment.scheduledEnd).getTime() -
-                new Date(appointment.scheduledStart).getTime()) /
-              60000
-            ).toString()
-          : '',
-        notes: appointment?.reason ?? '',
-      })
-  }, [open, patientId, appointment, form])
+    if (open) resetForm()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, patientId, appointment, initialDate, initialStart])
 
   useEffect(() => {
     form.setValue('patientId', appointment?.patientId ?? patientId ?? '')
@@ -103,12 +125,73 @@ export default function CreateAppointmentModal({
       .catch(() => toast.error('Error cargando pacientes'))
   }, [open, tenant])
 
+  const watchYear = form.watch('year')
+  const watchMonth = form.watch('month')
+  const watchDay = form.watch('day')
+
+  useEffect(() => {
+    const loadTimes = async () => {
+      if (!tenant || !watchYear || !watchMonth || !watchDay) return
+      const date = new Date(Number(watchYear), Number(watchMonth) - 1, Number(watchDay))
+      const hours = getWorkingHoursForDate(tenant.settings, date)
+      if (!hours) {
+        setTimes([])
+        return
+      }
+      try {
+        const list = await getAppointmentsInRange(
+          startOfDay(date),
+          endOfDay(date),
+          undefined,
+          tenant.tenantId,
+        )
+        setTimes(
+          generateTimeSlots(
+            date,
+            hours,
+            list,
+            tenant.settings.appointmentDurationMinutes,
+            10,
+            appointment?.appointmentId,
+          ),
+        )
+      } catch {
+        setTimes([])
+      }
+    }
+    loadTimes()
+  }, [tenant, watchYear, watchMonth, watchDay, appointment])
+
+  const watchStart = form.watch('startTime')
+  const [endTime, setEndTime] = useState('')
+  useEffect(() => {
+    if (!tenant || !watchYear || !watchMonth || !watchDay || !watchStart) {
+      setEndTime('')
+      return
+    }
+    const date = new Date(
+      Number(watchYear),
+      Number(watchMonth) - 1,
+      Number(watchDay),
+    )
+    const [h, m] = watchStart.split(':').map(Number)
+    date.setHours(h, m, 0, 0)
+    const end = new Date(date.getTime() + tenant.settings.appointmentDurationMinutes * 60000)
+    setEndTime(format(end, 'HH:mm'))
+  }, [tenant, watchYear, watchMonth, watchDay, watchStart])
+
   const submit = async (values: FormValues) => {
     setLoading(true)
     try {
-      const start = new Date(`${values.date}T${values.time}`)
-      const end = new Date(start.getTime() + Number(values.duration) * 60000)
       if (!user || !tenant) throw new Error('No user')
+      const start = new Date(
+        Number(values.year),
+        Number(values.month) - 1,
+        Number(values.day),
+      )
+      const [h, m] = values.startTime.split(':').map(Number)
+      start.setHours(h, m, 0, 0)
+      const end = new Date(start.getTime() + tenant.settings.appointmentDurationMinutes * 60000)
       if (appointment) {
         await updateAppointment(appointment.appointmentId, {
           ...appointment,
@@ -163,6 +246,9 @@ export default function CreateAppointmentModal({
     }
   }
 
+  const daysInMonth = watchMonth ? getDaysInMonth(new Date(Number(watchYear), Number(watchMonth) - 1)) : 31
+  const dayOptions = Array.from({ length: daysInMonth }, (_, i) => (i + 1).toString().padStart(2, '0'))
+
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent>
@@ -170,10 +256,7 @@ export default function CreateAppointmentModal({
           <DialogTitle>{appointment ? 'Editar cita' : 'Nueva cita'}</DialogTitle>
         </DialogHeader>
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(submit)}
-            className="space-y-3"
-          >
+          <form onSubmit={form.handleSubmit(submit)} className="space-y-3">
             <FormField
               control={form.control}
               name="patientId"
@@ -210,38 +293,91 @@ export default function CreateAppointmentModal({
             <div className="flex gap-2">
               <FormField
                 control={form.control}
-                name="date"
+                name="year"
                 render={({ field }) => (
                   <FormItem className="flex-1">
-                    <FormLabel>Fecha</FormLabel>
-                    <Input type="date" {...field} />
+                    <FormLabel>Año</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange} disabled>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={currentYear}>{currentYear}</SelectItem>
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}
               />
               <FormField
                 control={form.control}
-                name="time"
+                name="month"
                 render={({ field }) => (
                   <FormItem className="flex-1">
-                    <FormLabel>Hora</FormLabel>
-                    <Input type="time" {...field} />
+                    <FormLabel>Mes</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Mes" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Array.from({ length: 12 }, (_, i) => (
+                          <SelectItem key={i} value={String(i + 1).padStart(2, '0')}>
+                            {i + 1}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="day"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel>Día</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Día" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {dayOptions.map((d) => (
+                          <SelectItem key={d} value={d}>{d}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}
               />
             </div>
-            <FormField
-              control={form.control}
-              name="duration"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Duración (min)</FormLabel>
-                  <Input type="number" {...field} />
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className="flex gap-2">
+              <FormField
+                control={form.control}
+                name="startTime"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel>Hora inicio</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Hora" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {times.map((t) => (
+                          <SelectItem key={t} value={t}>{t}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex-1">
+                <FormLabel>Fin</FormLabel>
+                <Input value={endTime} readOnly />
+              </div>
+            </div>
             <FormField
               control={form.control}
               name="notes"

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -1,0 +1,50 @@
+import { format } from 'date-fns'
+import type { Appointment, TenantSettings } from '@/types/db'
+
+export function getWorkingHoursForDate(
+  settings: TenantSettings,
+  date: Date,
+): [string, string] | null {
+  const map = {
+    0: null, // Sunday
+    1: settings.workingHours.mon,
+    2: settings.workingHours.tue,
+    3: settings.workingHours.wed,
+    4: settings.workingHours.thu,
+    5: settings.workingHours.fri,
+    6: null, // Saturday
+  } as const
+  return map[date.getDay()] ?? null
+}
+
+export function generateTimeSlots(
+  date: Date,
+  workingHours: [string, string],
+  existing: Appointment[],
+  durationMinutes: number,
+  stepMinutes = 10,
+  ignoreId?: string,
+): string[] {
+  const [startH, startM] = workingHours[0].split(':').map(Number)
+  const [endH, endM] = workingHours[1].split(':').map(Number)
+
+  const start = new Date(date)
+  start.setHours(startH, startM, 0, 0)
+  const endBoundary = new Date(date)
+  endBoundary.setHours(endH, endM, 0, 0)
+
+  const slots: string[] = []
+  for (let cur = new Date(start); cur <= endBoundary; cur.setMinutes(cur.getMinutes() + stepMinutes)) {
+    const slotStart = new Date(cur)
+    const slotEnd = new Date(slotStart.getTime() + durationMinutes * 60000)
+    if (slotEnd > endBoundary) break
+    const overlap = existing.some((a) => {
+      if (ignoreId && a.appointmentId === ignoreId) return false
+      const apptStart = new Date(a.scheduledStart)
+      const apptEnd = new Date(a.scheduledEnd)
+      return slotStart < apptEnd && slotEnd > apptStart
+    })
+    if (!overlap) slots.push(format(slotStart, 'HH:mm'))
+  }
+  return slots
+}


### PR DESCRIPTION
## Summary
- create scheduling utilities to compute available slots using tenant settings
- overhaul CreateAppointmentModal to use discrete date/time selects
- support start time calculation and prevent overlap with existing appointments
- update dashboard calendar to prefill modal based on selected slot

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685ca0b2dc948333b1dd2a09ba02a991