### PR TITLE
Implement team management settings

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useContext } from 'react'
 import { Calendar, View, dateFnsLocalizer } from 'react-big-calendar'
 import {
   format,
@@ -17,7 +17,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css'
 import tw from 'tailwind-styled-components'
 import { getPatients } from '@/db/patients'
 import { getAppointmentsInRange } from '@/db/appointments'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import CreateAppointmentModal from '@/components/CreateAppointmentModal'
 import AppointmentDetailsPopup from '@/components/AppointmentDetailsPopup'
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
@@ -44,7 +44,7 @@ const views = [
 ]
 
 export default function DashboardCalendar() {
-  const { tenant } = useUser()
+  const { tenant } = useContext(UserContext)
   const [view, setView] = useState<View | null>(null)
   const [date, setDate] = useState(new Date())
   const [patients, setPatients] = useState<Patient[]>([])

--- a/src/app/(protected)/notifications/page.tsx
+++ b/src/app/(protected)/notifications/page.tsx
@@ -1,12 +1,12 @@
 'use client'
-import { useEffect, useState } from 'react'
-import { useUser } from '@/contexts/UserContext'
+import { useContext, useEffect, useState } from 'react'
+import { UserContext } from '@/contexts/UserContext'
 import { getNotifications, markNotificationAsRead } from '@/db/notifications'
 import type { Notification } from '@/types/db'
 import tw from 'tailwind-styled-components'
 
 export default function NotificationsPage() {
-  const { user } = useUser()
+  const { user } = useContext(UserContext)
   const [items, setItems] = useState<Notification[]>([])
 
   useEffect(() => {

--- a/src/app/(protected)/patients/[id]/page.tsx
+++ b/src/app/(protected)/patients/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import {
   getPatientById,
   getMedicalRecords,
@@ -22,7 +22,7 @@ import { Plus } from 'lucide-react'
 
 export default function PatientDetailsPage() {
   const params = useParams<{ id: string }>()
-  const { tenant } = useUser()
+  const { tenant } = useContext(UserContext)
   const [patient, setPatient] = useState<Patient | null>(null)
   const [records, setRecords] = useState<MedicalRecord[]>([])
   const [appointments, setAppointments] = useState<Appointment[]>([])

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { getPatients } from '@/db/patients'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import type { Patient } from '@/types/db'
 import {
   Table,
@@ -23,7 +23,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 const PAGE_SIZE = 10
 
 export default function PatientsPage() {
-  const { tenant } = useUser()
+  const { tenant } = useContext(UserContext)
   const [allPatients, setAllPatients] = useState<Patient[]>([])
   const [search, setSearch] = useState('')
   const [open, setOpen] = useState(false)

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,48 +1,28 @@
 'use client'
-import { useEffect, useState } from 'react'
-import { getOrganization, updateOrganization } from '@/db/organization'
-import { useUser } from '@/contexts/UserContext'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+import OrganizationSettingsForm from '@/components/OrganizationSettingsForm'
+import TeamSettings from '@/components/TeamSettings'
 import tw from 'tailwind-styled-components'
 
-export default function OrganizationSettingsPage() {
-  const { tenant } = useUser()
-  const [name, setName] = useState('')
-  const [phone, setPhone] = useState('')
-  const [address, setAddress] = useState('')
-
-  useEffect(() => {
-    if (!tenant) return
-    getOrganization(tenant.tenantId).then((t) => {
-      setName(t.name)
-      setPhone(t.phone)
-      setAddress(t.address)
-    })
-  }, [tenant])
-
-  if (!tenant) return null
-
-  const save = async () => {
-    await updateOrganization(tenant.tenantId, { name, phone, address })
-  }
+export default function SettingsPage() {
+  const [tab, setTab] = useState<'org' | 'team'>('org')
 
   return (
     <Wrapper>
-      <h1 className="text-lg font-medium">Ajustes de la clínica</h1>
-      <div className="space-y-3 max-w-md">
-        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nombre" />
-        <Input
-          type="tel"
-          value={phone}
-          onChange={(e) => setPhone(e.target.value)}
-          placeholder="Teléfono"
-        />
-        <Input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Dirección" />
-        <Button onClick={save}>Guardar</Button>
-      </div>
+      <Tabs>
+        <Tab $active={tab === 'org'} onClick={() => setTab('org')}>
+          Organización
+        </Tab>
+        <Tab $active={tab === 'team'} onClick={() => setTab('team')}>
+          Equipo
+        </Tab>
+      </Tabs>
+      {tab === 'org' ? <OrganizationSettingsForm /> : <TeamSettings />}
     </Wrapper>
   )
 }
 
-const Wrapper = tw.div`space-y-4 px-2 sm:px-4 pt-4`
+const Wrapper = tw.div`px-2 sm:px-4`
+const Tabs = tw.div`flex gap-4 border-b pt-4`
+const Tab = tw.button<{ $active?: boolean }>`pb-2 text-sm font-medium transition-colors
+  ${({ $active }) => ($active ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground')}`

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -14,7 +14,7 @@ export default function SettingsPage() {
           Organización
         </Tab>
         <Tab $active={tab === 'team'} onClick={() => setTab('team')}>
-          Equipo
+          Usuarios
         </Tab>
       </Tabs>
       {tab === 'org' ? <OrganizationSettingsForm /> : <TeamSettings />}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,6 +51,6 @@ const Main = tw.main`flex flex-col sm:flex-row gap-8 flex-1 items-start px-8`
 const Headline = tw.h1`text-4xl sm:text-5xl font-bold max-w-xl`
 const Screenshot = tw.div`
   hidden sm:flex items-center justify-center flex-1
-  rounded-xl border-2 border-primary p-4 h-auto bg-transparent
+  rounded-xl border-primary p-4 h-auto bg-transparent
 `
 const Footer = tw.footer`flex justify-end px-6 py-4`

--- a/src/components/CreateAppointmentModal.tsx
+++ b/src/components/CreateAppointmentModal.tsx
@@ -2,14 +2,14 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { getPatients } from '@/db/patients'
 import {
   createAppointment,
   updateAppointment,
   getAppointmentsInRange,
 } from '@/db/appointments'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import type { Patient, Appointment } from '@/types/db'
 import { toast } from 'sonner'
 import {
@@ -68,7 +68,7 @@ export default function CreateAppointmentModal({
   initialDate,
   initialStart,
 }: Props) {
-  const { user, tenant } = useUser()
+  const { user, tenant } = useContext(UserContext)
   const [patients, setPatients] = useState<Patient[]>([])
   const [loading, setLoading] = useState(false)
   const [times, setTimes] = useState<string[]>([])

--- a/src/components/CreatePatientModal.tsx
+++ b/src/components/CreatePatientModal.tsx
@@ -2,7 +2,8 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import PatientForm, { PatientFormValues } from "./PatientForm"
 import { createPatient } from "@/db/patients"
-import { useUser } from "@/contexts/UserContext"
+import { useContext } from "react"
+import { UserContext } from "@/contexts/UserContext"
 import { toast } from "sonner"
 import type { Patient } from "@/types/db"
 
@@ -15,7 +16,7 @@ export default function CreatePatientModal({
   onClose: () => void
   onCreated?: (p: Patient) => void
 }) {
-  const { user, tenant } = useUser()
+  const { user, tenant } = useContext(UserContext)
 
   const submit = async (values: PatientFormValues) => {
     try {

--- a/src/components/EditPatientModal.tsx
+++ b/src/components/EditPatientModal.tsx
@@ -2,7 +2,8 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import PatientForm, { PatientFormValues } from "./PatientForm"
 import { updatePatient } from "@/db/patients"
-import { useUser } from "@/contexts/UserContext"
+import { useContext } from 'react'
+import { UserContext } from '@/contexts/UserContext'
 import { toast } from "sonner"
 import type { Patient } from "@/types/db"
 
@@ -17,7 +18,7 @@ export default function EditPatientModal({
   patient: Patient
   onUpdated?: (p: Patient) => void
 }) {
-  const { user } = useUser()
+  const { user } = useContext(UserContext)
 
   const submit = async (values: PatientFormValues) => {
     try {

--- a/src/components/InviteUserModal.tsx
+++ b/src/components/InviteUserModal.tsx
@@ -1,0 +1,94 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { inviteUser } from '@/db/users'
+import { useUser } from '@/contexts/UserContext'
+import { toast } from 'sonner'
+import tw from 'tailwind-styled-components'
+import type { UserRole } from '@/types/db'
+
+const schema = z.object({
+  email: z.string().email('Correo inválido'),
+  role: z.enum(['admin', 'provider', 'staff']),
+})
+
+export type InviteFormValues = z.infer<typeof schema>
+
+export default function InviteUserModal({
+  open,
+  onClose,
+  onInvited,
+}: {
+  open: boolean
+  onClose: () => void
+  onInvited?: () => void
+}) {
+  const { tenant } = useUser()
+  const form = useForm<InviteFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', role: 'staff' },
+  })
+
+  const submit = async (values: InviteFormValues) => {
+    if (!tenant) return
+    try {
+      await inviteUser(tenant.tenantId, values.email, values.role as UserRole)
+      toast.success('Usuario invitado')
+      form.reset({ email: '', role: 'staff' })
+      onInvited?.()
+    } catch {
+      toast.error('No se pudo invitar usuario')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invitar usuario</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(submit)} className="space-y-3">
+          <div className="space-y-1">
+            <Input placeholder="correo@ejemplo.com" {...form.register('email')} />
+            {form.formState.errors.email && (
+              <ErrorText>{form.formState.errors.email.message}</ErrorText>
+            )}
+          </div>
+          <div className="space-y-1">
+            <Select
+              value={form.watch('role')}
+              onValueChange={(v) => form.setValue('role', v as UserRole)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Rol" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="staff">Staff</SelectItem>
+                <SelectItem value="provider">Provider</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+            {form.formState.errors.role && (
+              <ErrorText>{form.formState.errors.role.message}</ErrorText>
+            )}
+          </div>
+          <Button type="submit" className="w-full">
+            Invitar
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const ErrorText = tw.p`text-sm text-destructive`

--- a/src/components/MedicalRecordFormModal.tsx
+++ b/src/components/MedicalRecordFormModal.tsx
@@ -1,11 +1,11 @@
 'use client'
 import { useForm } from 'react-hook-form'
-import { useEffect } from 'react'
+import { useEffect, useContext } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { createMedicalRecord, updateMedicalRecord } from '@/db/patients'
 import { updateAppointment, getAppointmentById } from '@/db/appointments'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import { toast } from 'sonner'
 import {
   Form,
@@ -54,7 +54,7 @@ export default function MedicalRecordFormModal({
   record?: MedicalRecord | null
   onUpdated?: (rec: MedicalRecord) => void
 }) {
-  const { user, tenant } = useUser()
+  const { user, tenant } = useContext(UserContext)
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {

--- a/src/components/NotificationBellPopover.tsx
+++ b/src/components/NotificationBellPopover.tsx
@@ -1,15 +1,15 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Bell } from 'lucide-react'
 import { getNotifications, markNotificationAsRead } from '@/db/notifications'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import { toast } from 'sonner'
 import tw from 'tailwind-styled-components'
 import { Notification } from '@/types/db'
 import LoadingSpinner from './LoadingSpinner'
 
 export default function NotificationBellPopover() {
-  const { user } = useUser()
+  const { user } = useContext(UserContext)
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [notifications, setNotifications] = useState([] as Notification[])

--- a/src/components/OrganizationSettingsForm.tsx
+++ b/src/components/OrganizationSettingsForm.tsx
@@ -1,17 +1,38 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { getOrganization, updateOrganization } from '@/db/organization'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import tw from 'tailwind-styled-components'
 import { toast } from 'sonner'
 
 export default function OrganizationSettingsForm() {
-  const { tenant } = useUser()
+  const { tenant } = useContext(UserContext)
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')
   const [address, setAddress] = useState('')
+  const [email, setEmail] = useState('')
+  const [appointmentDuration, setAppointmentDuration] = useState(30)
+  // Fix workingHours type to match TenantSettings
+  type WorkingHours = {
+    mon: [string, string]
+    tue: [string, string]
+    wed: [string, string]
+    thu: [string, string]
+    fri: [string, string]
+    sat?: [string, string]
+    sun?: [string, string]
+  }
+  const [workingHours, setWorkingHours] = useState<WorkingHours>({
+    mon: ['08:00', '17:00'],
+    tue: ['08:00', '17:00'],
+    wed: ['08:00', '17:00'],
+    thu: ['08:00', '17:00'],
+    fri: ['08:00', '15:00'],
+    sat: ['08:00', '12:00'],
+    sun: ['', ''],
+  })
 
   useEffect(() => {
     if (!tenant) return
@@ -20,6 +41,17 @@ export default function OrganizationSettingsForm() {
         setName(t.name)
         setPhone(t.phone)
         setAddress(t.address)
+        setEmail(t.email || '')
+        setAppointmentDuration(t.settings?.appointmentDurationMinutes || 30)
+        setWorkingHours({
+          mon: t.settings?.workingHours?.mon || ['08:00', '17:00'],
+          tue: t.settings?.workingHours?.tue || ['08:00', '17:00'],
+          wed: t.settings?.workingHours?.wed || ['08:00', '17:00'],
+          thu: t.settings?.workingHours?.thu || ['08:00', '17:00'],
+          fri: t.settings?.workingHours?.fri || ['08:00', '15:00'],
+          sat: t.settings?.workingHours?.sat || ['08:00', '12:00'],
+          sun: t.settings?.workingHours?.sun || ['', ''],
+        })
       })
       .catch(() => toast.error('Error cargando datos'))
   }, [tenant])
@@ -28,21 +60,98 @@ export default function OrganizationSettingsForm() {
 
   const save = async () => {
     try {
-      await updateOrganization(tenant.tenantId, { name, phone, address })
+      await updateOrganization(tenant.tenantId, {
+        name,
+        email,
+        phone,
+        address,
+        settings: {
+          appointmentDurationMinutes: appointmentDuration,
+          workingHours,
+        },
+      })
       toast.success('Guardado')
     } catch {
       toast.error('No se pudo guardar')
     }
   }
 
+  const handleWorkingHourChange = (
+    day: keyof WorkingHours,
+    idx: 0 | 1,
+    value: string
+  ) => {
+    setWorkingHours((prev) => ({
+      ...prev,
+      [day]: [
+        idx === 0 ? value : prev[day]?.[0] || '',
+        idx === 1 ? value : prev[day]?.[1] || '',
+      ] as [string, string],
+    }))
+  }
+
+  const days: { key: keyof WorkingHours; label: string }[] = [
+    { key: 'mon', label: 'Lunes' },
+    { key: 'tue', label: 'Martes' },
+    { key: 'wed', label: 'Miércoles' },
+    { key: 'thu', label: 'Jueves' },
+    { key: 'fri', label: 'Viernes' },
+    { key: 'sat', label: 'Sábado' },
+    { key: 'sun', label: 'Domingo' },
+  ]
+
   return (
     <Wrapper>
       <h1 className="text-lg font-medium">Ajustes de la clínica</h1>
-      <div className="space-y-3 max-w-md">
-        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nombre" />
-        <Input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Teléfono" />
-        <Input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Dirección" />
-        <Button onClick={save}>Guardar</Button>
+      <div className="w-full flex flex-col md:flex-row gap-6">
+        <div className="w-full md:w-1/2 space-y-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">Nombre</label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nombre" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Correo electrónico</label>
+            <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Correo electrónico" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Teléfono</label>
+            <Input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Teléfono" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Dirección</label>
+            <Input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Dirección" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Duración común de cita (minutos)</label>
+            <Input type="number" min={5} max={180} value={appointmentDuration} onChange={e => setAppointmentDuration(Number(e.target.value))} />
+          </div>
+          <Button onClick={save}>Guardar</Button>
+        </div>
+        <div className="w-full md:w-1/2">
+          <label className="block text-sm font-medium mb-1">Horarios de atención</label>
+          <div className="grid grid-cols-1 gap-2">
+            {days.map(({ key, label }) => (
+              <div key={key} className="flex items-center gap-2">
+                <span className="w-24">{label}</span>
+                <Input
+                  type="time"
+                  value={workingHours[key]?.[0] || ''}
+                  onChange={e => handleWorkingHourChange(key, 0, e.target.value)}
+                  className="w-28"
+                  aria-label={`Hora inicio ${label}`}
+                />
+                <span>a</span>
+                <Input
+                  type="time"
+                  value={workingHours[key]?.[1] || ''}
+                  onChange={e => handleWorkingHourChange(key, 1, e.target.value)}
+                  className="w-28"
+                  aria-label={`Hora fin ${label}`}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </Wrapper>
   )

--- a/src/components/OrganizationSettingsForm.tsx
+++ b/src/components/OrganizationSettingsForm.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { getOrganization, updateOrganization } from '@/db/organization'
+import { useUser } from '@/contexts/UserContext'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import tw from 'tailwind-styled-components'
+import { toast } from 'sonner'
+
+export default function OrganizationSettingsForm() {
+  const { tenant } = useUser()
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [address, setAddress] = useState('')
+
+  useEffect(() => {
+    if (!tenant) return
+    getOrganization(tenant.tenantId)
+      .then((t) => {
+        setName(t.name)
+        setPhone(t.phone)
+        setAddress(t.address)
+      })
+      .catch(() => toast.error('Error cargando datos'))
+  }, [tenant])
+
+  if (!tenant) return null
+
+  const save = async () => {
+    try {
+      await updateOrganization(tenant.tenantId, { name, phone, address })
+      toast.success('Guardado')
+    } catch {
+      toast.error('No se pudo guardar')
+    }
+  }
+
+  return (
+    <Wrapper>
+      <h1 className="text-lg font-medium">Ajustes de la clínica</h1>
+      <div className="space-y-3 max-w-md">
+        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nombre" />
+        <Input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Teléfono" />
+        <Input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Dirección" />
+        <Button onClick={save}>Guardar</Button>
+      </div>
+    </Wrapper>
+  )
+}
+
+const Wrapper = tw.div`space-y-4 px-2 sm:px-4 pt-4`

--- a/src/components/TeamSettings.tsx
+++ b/src/components/TeamSettings.tsx
@@ -1,0 +1,99 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { getUsersByTenant } from '@/db/users'
+import { useUser } from '@/contexts/UserContext'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import InviteUserModal from './InviteUserModal'
+import { format } from 'date-fns'
+import tw from 'tailwind-styled-components'
+import { toast } from 'sonner'
+import LoadingSpinner from './LoadingSpinner'
+import type { User } from '@/types/db'
+
+export default function TeamSettings() {
+  const { tenant } = useUser()
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(false)
+  const [inviteOpen, setInviteOpen] = useState(false)
+
+  const loadUsers = async () => {
+    if (!tenant) return
+    setLoading(true)
+    try {
+      const list = await getUsersByTenant(tenant.tenantId)
+      setUsers(list)
+    } catch {
+      toast.error('Error al cargar usuarios')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadUsers()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenant])
+
+  const onInvited = () => {
+    setInviteOpen(false)
+    loadUsers()
+  }
+
+  if (!tenant) return null
+
+  return (
+    <Wrapper>
+      <Header>
+        <h1 className="text-lg font-medium">Equipo</h1>
+        <Button size="sm" onClick={() => setInviteOpen(true)}>
+          + Invitar usuario
+        </Button>
+      </Header>
+      {loading ? (
+        <div className="p-4 flex justify-center">
+          <LoadingSpinner className="h-5 w-5" />
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Rol</TableHead>
+              <TableHead>Creado</TableHead>
+              <TableHead>Último acceso</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-4 text-center">
+                  Sin usuarios
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((u) => (
+                <TableRow key={u.uid}>
+                  <TableCell>{u.email}</TableCell>
+                  <TableCell>
+                    <RoleTag $role={u.role}>{u.role}</RoleTag>
+                  </TableCell>
+                  <TableCell>{format(new Date(u.createdAt), 'dd/MM/yyyy')}</TableCell>
+                  <TableCell>
+                    {u.lastLoginAt ? format(new Date(u.lastLoginAt), 'dd/MM/yyyy') : '-'}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+      <InviteUserModal open={inviteOpen} onClose={() => setInviteOpen(false)} onInvited={onInvited} />
+    </Wrapper>
+  )
+}
+
+const Wrapper = tw.div`space-y-4 px-2 sm:px-4 pt-4`
+const Header = tw.div`flex justify-between items-center`
+const RoleTag = tw.span<{ $role: string }>`px-2 py-0.5 rounded text-xs capitalize
+  ${({ $role }) => ($role === 'admin' ? 'bg-primary/20 text-primary' : 'bg-muted')}`

--- a/src/components/TeamSettings.tsx
+++ b/src/components/TeamSettings.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { getUsersByTenant } from '@/db/users'
-import { useUser } from '@/contexts/UserContext'
+import { UserContext } from '@/contexts/UserContext'
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import InviteUserModal from './InviteUserModal'
@@ -12,7 +12,7 @@ import LoadingSpinner from './LoadingSpinner'
 import type { User } from '@/types/db'
 
 export default function TeamSettings() {
-  const { tenant } = useUser()
+  const { tenant } = useContext(UserContext)
   const [users, setUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(false)
   const [inviteOpen, setInviteOpen] = useState(false)

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,0 +1,44 @@
+import { db } from '@/lib/firebase'
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  setDoc,
+  where,
+} from 'firebase/firestore'
+import type { User, UserRole } from '@/types/db'
+
+export async function getUsersByTenant(tenantId: string): Promise<User[]> {
+  try {
+    const q = query(collection(db, 'users'), where('tenantId', '==', tenantId))
+    const snap = await getDocs(q)
+    return snap.docs.map((d) => ({ ...(d.data() as Omit<User, 'uid'>), uid: d.id }))
+  } catch (err) {
+    console.error('Error in getUsersByTenant:', err)
+    return []
+  }
+}
+
+export async function inviteUser(
+  tenantId: string,
+  email: string,
+  role: UserRole = 'staff',
+): Promise<void> {
+  try {
+    const ref = doc(collection(db, 'users'))
+    const now = new Date().toISOString()
+    await setDoc(ref, {
+      tenantId,
+      uid: ref.id,
+      email,
+      displayName: '',
+      role,
+      createdAt: now,
+      lastLoginAt: '',
+    })
+  } catch (err) {
+    console.error('Error in inviteUser:', err)
+    throw err
+  }
+}

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -42,6 +42,7 @@ export type User = {
   createdAt: string
   lastLoginAt: string
   avatarUrl?: string
+  invitedBy?: string
 }
 
 export type Patient = {


### PR DESCRIPTION
## Summary
- allow listing and inviting users by tenant
- add invite user modal
- expose organization settings form as reusable component
- add team management view under Settings

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_685cc8cee3508333b74b86452b6cb862