### PR TITLE
Add notifications panel

### DIFF
--- a/src/app/(protected)/notifications/page.tsx
+++ b/src/app/(protected)/notifications/page.tsx
@@ -1,43 +1,77 @@
 'use client'
 import { useContext, useEffect, useState } from 'react'
 import { UserContext } from '@/contexts/UserContext'
-import { getNotifications, markNotificationAsRead } from '@/db/notifications'
+import { listenToNotifications, markNotificationAsRead, archiveNotification } from '@/db/notifications'
 import type { Notification } from '@/types/db'
 import tw from 'tailwind-styled-components'
 
 export default function NotificationsPage() {
-  const { user } = useContext(UserContext)
+  const { user, tenant } = useContext(UserContext)
+  const [tab, setTab] = useState<'new' | 'archived'>('new')
   const [items, setItems] = useState<Notification[]>([])
 
   useEffect(() => {
-    if (!user) return
-    getNotifications(user.uid).then(setItems).catch(() => {})
-  }, [user])
+    if (!user || !tenant) return
+    const unsub = listenToNotifications(
+      user.uid,
+      tenant.tenantId,
+      { archived: tab === 'archived' },
+      (notifications) => setItems(notifications)
+    )
+    return () => unsub()
+  }, [user, tenant, tab])
 
   const markRead = async (id: string) => {
     await markNotificationAsRead(id)
-    setItems((prev) => prev.filter((n) => n.notificationId !== id))
+  }
+
+  const archive = async (id: string) => {
+    await archiveNotification(id)
   }
 
   if (!user) return null
 
   return (
     <Wrapper>
-      <h1 className="text-lg font-medium">Notificaciones</h1>
+      <Tabs>
+        <Tab $active={tab === 'new'} onClick={() => setTab('new')}>
+          Nuevas
+        </Tab>
+        <Tab $active={tab === 'archived'} onClick={() => setTab('archived')}>
+          Archivadas
+        </Tab>
+      </Tabs>
       <ul className="space-y-2">
-        {items.map((n) => (
-          <li key={n.notificationId} className="border p-2 rounded flex justify-between">
-            <span>{n.title}</span>
-            {!n.isRead && (
-              <button className="text-sm text-primary" onClick={() => markRead(n.notificationId)}>
-                Marcar como leída
-              </button>
-            )}
-          </li>
-        ))}
+        {items.length === 0 ? (
+          <li className="text-muted-foreground text-sm p-4 text-center">No hay notificaciones</li>
+        ) : (
+          items.map((n) => (
+            <li key={n.notificationId} className="border p-2 rounded flex justify-between items-center gap-2">
+              <div>
+                <span className="font-medium">{n.title}</span>
+                <div className="text-xs text-muted-foreground">{n.body}</div>
+              </div>
+              <div className="flex gap-2">
+                {!n.isRead && tab !== 'archived' && (
+                  <button className="text-sm text-primary" onClick={() => markRead(n.notificationId)}>
+                    Marcar como leída
+                  </button>
+                )}
+                {tab !== 'archived' && (
+                  <button className="text-sm text-muted-foreground" onClick={() => archive(n.notificationId)}>
+                    Archivar
+                  </button>
+                )}
+              </div>
+            </li>
+          ))
+        )}
       </ul>
     </Wrapper>
   )
 }
 
 const Wrapper = tw.div`space-y-4 px-2 sm:px-4 pt-4`
+const Tabs = tw.div`flex gap-4 border-b pt-4`
+const Tab = tw.button<{ $active?: boolean }>`pb-2 text-sm font-medium transition-colors
+  ${({ $active }) => ($active ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground')}`

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -78,9 +78,9 @@ export default function PatientsPage() {
           <Table className="min-w-[100px]">
             <TableHeader className="bg-muted">
               <TableRow>
-                <TableHead>Nombre</TableHead>
+                <TableHead className="min-w-[150px]">Nombre</TableHead>
                 <TableHead>Email</TableHead>
-                <TableHead>Teléfono</TableHead>
+                <TableHead className="min-w-[150px]">Teléfono</TableHead>
                 <TableHead></TableHead>
               </TableRow>
             </TableHeader>
@@ -104,9 +104,9 @@ export default function PatientsPage() {
                   className="cursor-pointer hover:bg-[var(--primary-soft)]"
                   onClick={() => router.push(`/patients/${p.patientId}`)}
                 >
-                  <TableCell>{p.firstName} {p.lastName}</TableCell>
+                  <TableCell className="min-w-max">{p.firstName} {p.lastName}</TableCell>
                   <TableCell>{p.email}</TableCell>
-                  <TableCell>{p.phone}</TableCell>
+                  <TableCell className="min-w-max">{p.phone}</TableCell>
                   <TableCell>
                     <Link className="text-primary" href={`/patients/${p.patientId}`}>Ver</Link>
                   </TableCell>

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -149,5 +149,5 @@ export default function PatientsPage() {
   )
 }
 
-const Wrapper = tw.div`flex flex-col gap-4 px-2 sm:px-4 pt-4`
+const Wrapper = tw.div`flex flex-col gap-4 px-2 sm:px-4 pt-8`
 const Header = tw.div`flex justify-between items-center`

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -22,7 +22,7 @@ export default function SettingsPage() {
   )
 }
 
-const Wrapper = tw.div`px-2 sm:px-4`
+const Wrapper = tw.div`space-y-4 px-2 sm:px-4 pt-4`
 const Tabs = tw.div`flex gap-4 border-b pt-4`
 const Tab = tw.button<{ $active?: boolean }>`pb-2 text-sm font-medium transition-colors
   ${({ $active }) => ($active ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground')}`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import {
   Calendar,
   Users,
-  Bell,
   Settings,
   ChevronsLeft,
   ChevronsRight,
@@ -13,12 +12,12 @@ import {
 import { useState } from 'react'
 import Image from 'next/image'
 import UserSettings from '@/components/UserSettings'
+import SidebarNotificationsPanel from './SidebarNotificationsPanel'
 import tw from 'tailwind-styled-components'
 
 const navItems = [
   { href: '/dashboard', label: 'Calendario', icon: Calendar },
   { href: '/patients', label: 'Pacientes', icon: Users },
-  { href: '/notifications', label: 'Notificaciones', icon: Bell },
   { href: '/settings', label: 'Ajustes', icon: Settings },
 ]
 
@@ -62,6 +61,7 @@ export default function Sidebar() {
               </Link>
             </NavItem>
           ))}
+          <SidebarNotificationsPanel collapsed={collapsed} />
         </NavList>
       </TopSection>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,16 +8,17 @@ import {
   Settings,
   ChevronsLeft,
   ChevronsRight,
+  Bell,
 } from 'lucide-react'
 import { useState } from 'react'
 import Image from 'next/image'
 import UserSettings from '@/components/UserSettings'
-import SidebarNotificationsPanel from './SidebarNotificationsPanel'
 import tw from 'tailwind-styled-components'
 
 const navItems = [
   { href: '/dashboard', label: 'Calendario', icon: Calendar },
   { href: '/patients', label: 'Pacientes', icon: Users },
+  { href: '/notifications', label: 'Notificaciones', icon: Bell },
   { href: '/settings', label: 'Ajustes', icon: Settings },
 ]
 
@@ -61,7 +62,6 @@ export default function Sidebar() {
               </Link>
             </NavItem>
           ))}
-          <SidebarNotificationsPanel collapsed={collapsed} />
         </NavList>
       </TopSection>
 

--- a/src/components/SidebarNotificationsPanel.tsx
+++ b/src/components/SidebarNotificationsPanel.tsx
@@ -109,66 +109,77 @@ export default function SidebarNotificationsPanel({
         {unreadCount > 0 && <Badge>{unreadCount}</Badge>}
       </BellButton>
       <Dialog open={open} onOpenChange={(v) => !v && setOpen(false)}>
-        <DialogContent
-          showCloseButton={false}
-          className="fixed right-0 top-0 h-full max-w-xs w-full rounded-none p-0"
-        >
-          <PanelWrapper>
-            <Header>
-              <DialogHeader>
-                <DialogTitle>Notificaciones</DialogTitle>
-              </DialogHeader>
-              <Tabs>
-                <Tab $active={tab === "all"} onClick={() => setTab("all")}>Todo</Tab>
-                <Tab
-                  $active={tab === "archived"}
-                  onClick={() => setTab("archived")}
-                >
-                  Archivado
-                </Tab>
-              </Tabs>
-            </Header>
-            <List ref={listRef}>
-              {notifications.length === 0 ? (
-                <EmptyState>No hay notificaciones</EmptyState>
-              ) : (
-                notifications.map((n) => (
-                  <Item key={n.notificationId} $unread={!n.isRead}>
-                    <div>
-                      <p className="font-medium">{n.title}</p>
-                      <p className="text-sm text-muted-foreground">{n.body}</p>
-                    </div>
-                    <div className="flex gap-2">
-                      {!n.isRead && (
-                        <Button
-                          variant="link"
-                          size="sm"
-                          onClick={() => markRead(n.notificationId)}
-                        >
-                          Leer
-                        </Button>
-                      )}
-                      {tab !== "archived" && (
-                        <Button
-                          variant="link"
-                          size="sm"
-                          onClick={() => archive(n.notificationId)}
-                        >
-                          Archivar
-                        </Button>
-                      )}
-                    </div>
-                  </Item>
-                ))
-              )}
-              {loadingMore && (
-                <div className="py-4 flex justify-center">
-                  <LoadingSpinner className="h-4 w-4" />
-                </div>
-              )}
-            </List>
-          </PanelWrapper>
-        </DialogContent>
+        <div className="fixed inset-0 z-50">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setOpen(false)}
+          />
+          <DialogContent
+            showCloseButton={false}
+            className="fixed right-0 top-0 h-full max-w-xs w-full rounded-none p-0 z-50 shadow-2xl bg-white dark:bg-background border-l border-border"
+            style={{ boxShadow: "rgba(0,0,0,0.15) -4px 0px 24px" }}
+          >
+            <PanelWrapper>
+              <Header>
+                <DialogHeader>
+                  <DialogTitle>Notificaciones</DialogTitle>
+                </DialogHeader>
+                <Tabs>
+                  <Tab $active={tab === "all"} onClick={() => setTab("all")}>
+                    Todo
+                  </Tab>
+                  <Tab
+                    $active={tab === "archived"}
+                    onClick={() => setTab("archived")}
+                  >
+                    Archivado
+                  </Tab>
+                </Tabs>
+              </Header>
+              <List ref={listRef}>
+                {notifications.length === 0 ? (
+                  <EmptyState>No hay notificaciones</EmptyState>
+                ) : (
+                  notifications.map((n) => (
+                    <Item key={n.notificationId} $unread={!n.isRead}>
+                      <div>
+                        <p className="font-medium">{n.title}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {n.body}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        {!n.isRead && (
+                          <Button
+                            variant="link"
+                            size="sm"
+                            onClick={() => markRead(n.notificationId)}
+                          >
+                            Leer
+                          </Button>
+                        )}
+                        {tab !== "archived" && (
+                          <Button
+                            variant="link"
+                            size="sm"
+                            onClick={() => archive(n.notificationId)}
+                          >
+                            Archivar
+                          </Button>
+                        )}
+                      </div>
+                    </Item>
+                  ))
+                )}
+                {loadingMore && (
+                  <div className="py-4 flex justify-center">
+                    <LoadingSpinner className="h-4 w-4" />
+                  </div>
+                )}
+              </List>
+            </PanelWrapper>
+          </DialogContent>
+        </div>
       </Dialog>
     </>
   )

--- a/src/components/SidebarNotificationsPanel.tsx
+++ b/src/components/SidebarNotificationsPanel.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import { useCallback, useContext, useEffect, useRef, useState } from "react"
+import { Bell } from "lucide-react"
+import {
+  archiveNotification,
+  listenToNotifications,
+  getMoreNotifications,
+  markNotificationAsRead,
+} from "@/db/notifications"
+import { UserContext } from "@/contexts/UserContext"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import tw from "tailwind-styled-components"
+import type { Notification } from "@/types/db"
+import type { QueryDocumentSnapshot } from "firebase/firestore"
+import LoadingSpinner from "./LoadingSpinner"
+import { toast } from "sonner"
+
+export default function SidebarNotificationsPanel({
+  collapsed,
+}: {
+  collapsed: boolean
+}) {
+  const { user, tenant } = useContext(UserContext)
+  const [open, setOpen] = useState(false)
+  const [tab, setTab] = useState<"all" | "archived">("all")
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!user || !tenant) return
+    const unsub = listenToNotifications(
+      user.uid,
+      tenant.tenantId,
+      { archived: tab === "archived" },
+      (items, last) => {
+        setNotifications(items)
+        setLastDoc(last)
+        setUnreadCount(items.filter((n) => !n.isRead).length)
+      },
+    )
+    return () => unsub()
+  }, [user, tenant, tab])
+
+  const loadMore = useCallback(async () => {
+    if (!user || !tenant || !lastDoc) return
+    setLoadingMore(true)
+    try {
+      const { items, lastDoc: newLast } = await getMoreNotifications(
+        user.uid,
+        tenant.tenantId,
+        { archived: tab === "archived", startAfterDoc: lastDoc },
+      )
+      setNotifications((prev) => {
+        const ids = new Set(prev.map((n) => n.notificationId))
+        return [...prev, ...items.filter((n) => !ids.has(n.notificationId))]
+      })
+      setLastDoc(newLast)
+    } catch (err) {
+      console.error("Error loading more notifications:", err)
+      toast.error("Error al cargar notificaciones")
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [user, tenant, lastDoc, tab])
+
+  useEffect(() => {
+    const el = listRef.current
+    if (!el) return
+    const onScroll = () => {
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) loadMore()
+    }
+    el.addEventListener("scroll", onScroll)
+    return () => el.removeEventListener("scroll", onScroll)
+  }, [loadMore])
+
+  const markRead = async (id: string) => {
+    try {
+      await markNotificationAsRead(id)
+    } catch {
+      toast.error("No se pudo marcar como leída")
+    }
+  }
+
+  const archive = async (id: string) => {
+    try {
+      await archiveNotification(id)
+    } catch {
+      toast.error("No se pudo archivar")
+    }
+  }
+
+  if (!user || !tenant) return null
+
+  return (
+    <>
+      <BellButton onClick={() => setOpen(true)} $collapsed={collapsed}>
+        <Bell size={20} />
+        {!collapsed && <span>Notificaciones</span>}
+        {unreadCount > 0 && <Badge>{unreadCount}</Badge>}
+      </BellButton>
+      <Dialog open={open} onOpenChange={(v) => !v && setOpen(false)}>
+        <DialogContent
+          showCloseButton={false}
+          className="fixed right-0 top-0 h-full max-w-xs w-full rounded-none p-0"
+        >
+          <PanelWrapper>
+            <Header>
+              <DialogHeader>
+                <DialogTitle>Notificaciones</DialogTitle>
+              </DialogHeader>
+              <Tabs>
+                <Tab $active={tab === "all"} onClick={() => setTab("all")}>Todo</Tab>
+                <Tab
+                  $active={tab === "archived"}
+                  onClick={() => setTab("archived")}
+                >
+                  Archivado
+                </Tab>
+              </Tabs>
+            </Header>
+            <List ref={listRef}>
+              {notifications.length === 0 ? (
+                <EmptyState>No hay notificaciones</EmptyState>
+              ) : (
+                notifications.map((n) => (
+                  <Item key={n.notificationId} $unread={!n.isRead}>
+                    <div>
+                      <p className="font-medium">{n.title}</p>
+                      <p className="text-sm text-muted-foreground">{n.body}</p>
+                    </div>
+                    <div className="flex gap-2">
+                      {!n.isRead && (
+                        <Button
+                          variant="link"
+                          size="sm"
+                          onClick={() => markRead(n.notificationId)}
+                        >
+                          Leer
+                        </Button>
+                      )}
+                      {tab !== "archived" && (
+                        <Button
+                          variant="link"
+                          size="sm"
+                          onClick={() => archive(n.notificationId)}
+                        >
+                          Archivar
+                        </Button>
+                      )}
+                    </div>
+                  </Item>
+                ))
+              )}
+              {loadingMore && (
+                <div className="py-4 flex justify-center">
+                  <LoadingSpinner className="h-4 w-4" />
+                </div>
+              )}
+            </List>
+          </PanelWrapper>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+const BellButton = tw.button<{ $collapsed: boolean }>`
+  w-full flex items-center gap-2 relative text-muted-foreground hover:bg-muted rounded-lg transition-colors
+  ${({ $collapsed }) => ($collapsed ? 'justify-center p-3' : 'px-4 py-3')}
+`
+
+const Badge = tw.span`
+  bg-destructive text-white text-xs rounded-full px-1 min-w-4 h-4 flex items-center justify-center absolute top-1 right-1
+`
+
+const PanelWrapper = tw.div`flex flex-col h-full`
+const Header = tw.div`p-4 border-b space-y-2`
+const Tabs = tw.div`flex gap-4 border-b pb-2`
+const Tab = tw.button<{ $active?: boolean }>`text-sm font-medium transition-colors pb-1
+  ${({ $active }) => ($active ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground')}`
+
+const List = tw.div`flex-1 overflow-y-auto`
+const Item = tw.div<{ $unread?: boolean }>`flex justify-between items-start gap-2 p-3 border-b text-sm
+  ${({ $unread }) => $unread && 'bg-primary/5'}
+`
+const EmptyState = tw.div`p-4 text-center text-sm text-muted-foreground`
+

--- a/src/db/notifications.ts
+++ b/src/db/notifications.ts
@@ -1,5 +1,17 @@
 import { db } from '@/lib/firebase'
-import { collection, query, where, getDocs, doc, updateDoc } from 'firebase/firestore'
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  updateDoc,
+  onSnapshot,
+  orderBy,
+  limit,
+  QueryDocumentSnapshot,
+  startAfter,
+} from 'firebase/firestore'
 import { Notification } from '@/types/db'
 
 export async function getNotifications(userId: string): Promise<Notification[]> {
@@ -22,5 +34,80 @@ export async function markNotificationAsRead(id: string): Promise<void> {
   } catch (err) {
     console.error('Error in markNotificationAsRead:', err)
     throw err
+  }
+}
+
+export async function archiveNotification(id: string): Promise<void> {
+  try {
+    await updateDoc(doc(db, 'notifications', id), { archived: true })
+  } catch (err) {
+    console.error('Error in archiveNotification:', err)
+    throw err
+  }
+}
+
+export function listenToNotifications(
+  userId: string,
+  tenantId: string,
+  options: { archived?: boolean; limit?: number } = {},
+  onChange?: (
+    items: Notification[],
+    lastDoc: QueryDocumentSnapshot | null,
+  ) => void,
+) {
+  try {
+    const q = query(
+      collection(db, 'notifications'),
+      where('userId', '==', userId),
+      where('tenantId', '==', tenantId),
+      where('archived', '==', options.archived ?? false),
+      orderBy('createdAt', 'desc'),
+      limit(options.limit ?? 10),
+    )
+    // Firestore composite index required for: userId + tenantId + archived + createdAt
+    return onSnapshot(q, (snap) => {
+      const list = snap.docs.map((d) => ({
+        ...(d.data() as Omit<Notification, 'notificationId'>),
+        notificationId: d.id,
+      })) as Notification[]
+      onChange?.(list, snap.docs[snap.docs.length - 1] ?? null)
+    })
+  } catch (err) {
+    console.error('Error in listenToNotifications:', err)
+    return () => {}
+  }
+}
+
+export async function getMoreNotifications(
+  userId: string,
+  tenantId: string,
+  options: {
+    archived?: boolean
+    limit?: number
+    startAfterDoc: QueryDocumentSnapshot
+  },
+): Promise<{ items: Notification[]; lastDoc: QueryDocumentSnapshot | null }> {
+  try {
+    const q = query(
+      collection(db, 'notifications'),
+      where('userId', '==', userId),
+      where('tenantId', '==', tenantId),
+      where('archived', '==', options.archived ?? false),
+      orderBy('createdAt', 'desc'),
+      startAfter(options.startAfterDoc),
+      limit(options.limit ?? 10),
+    )
+    // Firestore composite index required for: userId + tenantId + archived + createdAt
+    const snap = await getDocs(q)
+    return {
+      items: snap.docs.map((d) => ({
+        ...(d.data() as Omit<Notification, 'notificationId'>),
+        notificationId: d.id,
+      })) as Notification[],
+      lastDoc: snap.docs[snap.docs.length - 1] ?? null,
+    }
+  } catch (err) {
+    console.error('Error in getMoreNotifications:', err)
+    return { items: [], lastDoc: null }
   }
 }


### PR DESCRIPTION
## Summary
- add Firestore helpers for listening, pagination and archiving notifications
- implement sidebar notifications panel with tabs and pagination
- integrate the new panel into the sidebar

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686ef839f6a883338d83b5256065331e