### PR TITLE
Improve landing page SEO metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,10 +15,51 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "MidiMed",
-  description: "Gestión moderna de pacientes y citas para clínicas y consultorios.",
+  title:
+    "MidiMed - Gestiona fácilmente tus pacientes, citas y expedientes médicos",
+  description:
+    "Gestiona fácilmente tus pacientes, citas y expedientes médicos.",
+  keywords: [
+    "pacientes",
+    "citas",
+    "expedientes médicos",
+    "gestión clínica",
+    "MidiMed",
+  ],
+  authors: [{ name: "MidiMed" }],
+  openGraph: {
+    title:
+      "MidiMed - Gestiona fácilmente tus pacientes, citas y expedientes médicos",
+    description:
+      "Gestiona fácilmente tus pacientes, citas y expedientes médicos.",
+    url: "https://midimed.app",
+    siteName: "MidiMed",
+    images: [
+      {
+        url: "/logoPrimary.svg",
+        width: 800,
+        height: 600,
+        alt: "MidiMed logo",
+      },
+    ],
+    locale: "es_ES",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title:
+      "MidiMed - Gestiona fácilmente tus pacientes, citas y expedientes médicos",
+    description:
+      "Gestiona fácilmente tus pacientes, citas y expedientes médicos.",
+    images: ["/logoPrimary.svg"],
+    creator: "@midimed",
+  },
   icons: {
     icon: "/logo.svg",
+  },
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
   },
 };
 
@@ -28,7 +69,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="es">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- add rich SEO metadata for the landing layout
- set page language to Spanish

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_687069b0766c833380cfa468bc796413