### PR TITLE
Apply Source Sans Pro globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro).
 
 ## Learn More
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "midimed",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/geist-mono": "^5.2.6",
+        "@fontsource/source-sans-pro": "^5.2.5",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -916,6 +918,21 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/geist-mono": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-mono/-/geist-mono-5.2.6.tgz",
+      "integrity": "sha512-I3hsRP+8Gmhk35cwlPAR4w5xqk7e5pro2F1o51ZmB+lN+dPcwN3jYHKN+u0E5AMuiQKpTdkrqfEpvBjzQax3cQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-sans-pro": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.2.5.tgz",
+      "integrity": "sha512-ypendqc4pYUc+EgF7qqPY9iVYEz1t/Qr03VojKxG/2g3dnpHa1B6DOlDxWQjQXDj5QrG6inEqGT0g+edjALZyg==",
+      "license": "OFL-1.1"
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format": "next lint --fix"
   },
   "dependencies": {
+    "@fontsource/geist-mono": "^5.2.6",
+    "@fontsource/source-sans-pro": "^5.2.5",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-source-sans-pro);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,34 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 import { UserProvider } from '@/contexts/UserContext'
 import { Toaster } from "sonner";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+const sourceSansPro = localFont({
+  variable: "--font-source-sans-pro",
+  src: [
+    {
+      path: "../../node_modules/@fontsource/source-sans-pro/files/source-sans-pro-latin-400-normal.woff2",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../../node_modules/@fontsource/source-sans-pro/files/source-sans-pro-latin-700-normal.woff2",
+      weight: "700",
+      style: "normal",
+    },
+  ],
 });
 
-const geistMono = Geist_Mono({
+const geistMono = localFont({
   variable: "--font-geist-mono",
-  subsets: ["latin"],
+  src: [
+    {
+      path: "../../node_modules/@fontsource/geist-mono/files/geist-mono-latin-400-normal.woff2",
+      weight: "400",
+      style: "normal",
+    },
+  ],
 });
 
 export const metadata: Metadata = {
@@ -30,7 +47,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${sourceSansPro.variable} ${geistMono.variable} font-sans antialiased`}
       >
         <UserProvider>
           {children}

--- a/src/components/ReportsDashboard.tsx
+++ b/src/components/ReportsDashboard.tsx
@@ -8,6 +8,7 @@ import tw from 'tailwind-styled-components'
 import { Bar } from 'react-chartjs-2'
 import { Chart, CategoryScale, LinearScale, BarElement, Tooltip, Legend } from 'chart.js'
 import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
 
 Chart.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
 
@@ -181,7 +182,7 @@ export default function ReportsDashboard() {
 
       // Crear contenedor temporal para el PDF
       const pdfContainer = document.createElement('div')
-      pdfContainer.style.fontFamily = 'Arial, sans-serif'
+      pdfContainer.style.fontFamily = '"Source Sans Pro", sans-serif'
       pdfContainer.style.backgroundColor = '#ffffff'
       pdfContainer.style.padding = '20px'
 
@@ -364,10 +365,10 @@ export default function ReportsDashboard() {
 
     } catch (error) {
       console.error('Error al generar PDF:', error)
-      alert('Error al generar el PDF. Por favor, intenta nuevamente.')
+      toast.error('Error al generar el PDF. Por favor, intenta nuevamente.')
 
       // Limpiar en caso de error
-      const tempContainer = document.querySelector('div[style*="font-family: Arial"]')
+      const tempContainer = document.querySelector('div[style*="font-family: Source Sans Pro"]')
       if (tempContainer) {
         document.body.removeChild(tempContainer)
       }

--- a/src/lib/pdf-generator.ts
+++ b/src/lib/pdf-generator.ts
@@ -62,7 +62,7 @@ export async function generateReportPDF({
 
   // Crear contenedor temporal para el PDF
   const pdfContainer = document.createElement('div')
-  pdfContainer.style.fontFamily = 'Arial, sans-serif'
+  pdfContainer.style.fontFamily = '"Source Sans Pro", sans-serif'
   pdfContainer.style.backgroundColor = '#ffffff'
   pdfContainer.style.padding = '20px'
   pdfContainer.style.position = 'fixed'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,10 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-sans)', 'sans-serif'],
+        mono: ['var(--font-mono)', 'monospace'],
+      },
       colors: {
         primary: '#3abdd4',
         danger: '#ff3564',


### PR DESCRIPTION
## Summary
- load Source Sans Pro and Geist Mono locally
- extend Tailwind with font families
- update PDF generators to use the new font
- use toast instead of alert in ReportsDashboard
- document new font in README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f3176b0b88333a5473da2d5350ac1