### PR TITLE
feat: add patient file management

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["http://localhost:3000", "https://midimed.tech"],
+    "method": ["GET", "POST", "PUT", "DELETE"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type", "Authorization"]
+  }
+]

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig = {
     config.resolve.alias["@"] = path.resolve(__dirname, "src");
     return config;
   },
+  images: {
+    domains: ["firebasestorage.googleapis.com"],
+  },
 };
 
 module.exports = nextConfig;

--- a/src/app/(protected)/patients/[id]/page.tsx
+++ b/src/app/(protected)/patients/[id]/page.tsx
@@ -17,6 +17,7 @@ import EditPatientModal from '@/components/EditPatientModal'
 import PatientInfoCard from '@/components/PatientInfoCard'
 import PatientAppointmentsTable from '@/components/PatientAppointmentsTable'
 import PatientRecordsTable from '@/components/PatientRecordsTable'
+import PatientFilesTable from '@/components/PatientFilesTable'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 
@@ -139,8 +140,16 @@ export default function PatientDetailsPage() {
               }}
             />
           </Section>
+          <Section>
+            <h2 className="font-medium text-lg mb-2">Archivos del paciente</h2>
+            <PatientFilesTable patientId={patient.patientId} />
+          </Section>
         </div>
-        <PatientInfoCard patient={patient} onEdit={() => setOpenEdit(true)} />
+        <PatientInfoCard
+          patient={patient}
+          onEdit={() => setOpenEdit(true)}
+          onPhotoChange={(url) => setPatient((prev) => (prev ? { ...prev, photoUrl: url } : prev))}
+        />
       </div>
       <CreateAppointmentModal
         open={openAppt}

--- a/src/app/(protected)/patients/[id]/page.tsx
+++ b/src/app/(protected)/patients/[id]/page.tsx
@@ -8,9 +8,10 @@ import {
   deleteMedicalRecord,
 } from '@/db/patients'
 import { getAppointmentsInRange, deleteAppointment } from '@/db/appointments'
-import type { Patient, MedicalRecord, Appointment, AppointmentStatus } from '@/types/db'
+import type { Patient, MedicalRecord, Appointment, AppointmentStatus, PatientFile } from '@/types/db'
 import CreateAppointmentModal from '@/components/CreateAppointmentModal'
 import MedicalRecordFormModal from '@/components/MedicalRecordFormModal'
+import UploadFileModal from '@/components/UploadFileModal'
 import tw from 'tailwind-styled-components'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import EditPatientModal from '@/components/EditPatientModal'
@@ -27,11 +28,13 @@ export default function PatientDetailsPage() {
   const [patient, setPatient] = useState<Patient | null>(null)
   const [records, setRecords] = useState<MedicalRecord[]>([])
   const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [files, setFiles] = useState<PatientFile[]>([])
   const [openAppt, setOpenAppt] = useState(false)
   const [editingAppt, setEditingAppt] = useState<Appointment | null>(null)
   const [openRecord, setOpenRecord] = useState(false)
   const [editingRecord, setEditingRecord] = useState<MedicalRecord | null>(null)
   const [openEdit, setOpenEdit] = useState(false)
+  const [openUpload, setOpenUpload] = useState(false)
   const [completingAppt, setCompletingAppt] = useState<Appointment | null>(null)
 
   const translateStatus = (status: AppointmentStatus) => {
@@ -141,8 +144,17 @@ export default function PatientDetailsPage() {
             />
           </Section>
           <Section>
-            <h2 className="font-medium text-lg mb-2">Archivos del paciente</h2>
-            <PatientFilesTable patientId={patient.patientId} />
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="font-medium text-lg">Archivos del paciente</h2>
+              <Button size="sm" onClick={() => setOpenUpload(true)} className="flex items-center gap-1">
+                Nuevo archivo <Plus size={14} />
+              </Button>
+            </div>
+            <PatientFilesTable 
+              patientId={patient.patientId} 
+              files={files}
+              onFilesChange={setFiles}
+            />
           </Section>
         </div>
         <PatientInfoCard
@@ -198,6 +210,12 @@ export default function PatientDetailsPage() {
         onClose={() => setOpenEdit(false)}
         patient={patient}
         onUpdated={(p) => setPatient(p)}
+      />
+      <UploadFileModal
+        open={openUpload}
+        onClose={() => setOpenUpload(false)}
+        patientId={patient.patientId}
+        onUploaded={(newFiles) => setFiles((prev) => [...prev, ...newFiles])}
       />
     </Wrapper>
   )

--- a/src/components/NotificationBellPopover.tsx
+++ b/src/components/NotificationBellPopover.tsx
@@ -17,7 +17,6 @@ export default function NotificationBellPopover() {
   useEffect(() => {
     if (!user || !tenant) return
     
-    console.log('🔔 Setting up notification bell listener')
     setLoading(true)
     
     const unsub = listenToNotifications(
@@ -25,7 +24,6 @@ export default function NotificationBellPopover() {
       tenant.tenantId,
       { archived: false, limit: 5 },
       (notificationList) => {
-        console.log('🔔 Bell received notifications:', notificationList)
         // Filter only unread notifications for the bell
         const unreadNotifications = notificationList.filter((n) => !n.isRead)
         setNotifications(unreadNotifications)

--- a/src/components/PatientFilesTable.tsx
+++ b/src/components/PatientFilesTable.tsx
@@ -1,52 +1,34 @@
 "use client"
 
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect } from 'react'
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
-import { Upload, Trash, Download } from 'lucide-react'
-import { getPatientFiles, uploadPatientFile, deletePatientFile } from '@/db/patientFiles'
+import { Trash, Download } from 'lucide-react'
+import { getPatientFiles, deletePatientFile } from '@/db/patientFiles'
 import { UserContext } from '@/contexts/UserContext'
 import type { PatientFile } from '@/types/db'
 import { toast } from 'sonner'
 import { format } from 'date-fns'
-import tw from 'tailwind-styled-components'
 
-export default function PatientFilesTable({ patientId }: { patientId: string }) {
-  const { tenant, user } = useContext(UserContext)
-  const [files, setFiles] = useState<PatientFile[]>([])
-  const [uploading, setUploading] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
+export default function PatientFilesTable({ 
+  patientId, 
+  files, 
+  onFilesChange 
+}: { 
+  patientId: string
+  files: PatientFile[]
+  onFilesChange: (files: PatientFile[]) => void
+}) {
+  const { tenant } = useContext(UserContext)
 
   useEffect(() => {
     if (tenant)
-      getPatientFiles(patientId, tenant.tenantId).then(setFiles).catch(() => { })
-  }, [patientId, tenant])
-
-  const handleUpload = async (list: FileList | null) => {
-    if (!list || !tenant || !user) return
-    try {
-      setUploading(true)
-      const results = await Promise.all(
-        Array.from(list).map((f) => uploadPatientFile(patientId, tenant.tenantId, user.uid, f)),
-      )
-      setFiles((prev) => [...prev, ...results])
-      toast.success('Archivo subido')
-    } catch {
-      toast.error('Error al subir archivo')
-    } finally {
-      setUploading(false)
-      if (inputRef.current) inputRef.current.value = ''
-    }
-  }
-
-  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    handleUpload(e.dataTransfer.files)
-  }
+      getPatientFiles(patientId, tenant.tenantId).then(onFilesChange).catch(() => { })
+  }, [patientId, tenant, onFilesChange])
 
   const remove = async (file: PatientFile) => {
     try {
       await deletePatientFile(file.fileId, file.storagePath)
-      setFiles((prev) => prev.filter((f) => f.fileId !== file.fileId))
+      onFilesChange(files.filter((f) => f.fileId !== file.fileId))
       toast.success('Archivo eliminado')
     } catch {
       toast.error('Error al eliminar archivo')
@@ -54,56 +36,40 @@ export default function PatientFilesTable({ patientId }: { patientId: string }) 
   }
 
   return (
-    <div>
-      <DropZone
-        onDragOver={(e: React.DragEvent<HTMLDivElement>) => e.preventDefault()}
-        onDrop={onDrop}
-        onClick={() => inputRef.current?.click()}
-      >
-        <Upload size={16} />
-        <span>{uploading ? 'Subiendo...' : 'Arrastra archivos o haz click para subir'}</span>
-        <input ref={inputRef} type="file" multiple className="hidden" onChange={(e) => handleUpload(e.target.files)} />
-      </DropZone>
-      <div className="overflow-x-auto mt-4">
-        <Table className="min-w-[500px]">
-          <TableHeader>
+    <div className="overflow-x-auto">
+      <Table className="min-w-[500px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nombre</TableHead>
+            <TableHead>Fecha</TableHead>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {files.length === 0 ? (
             <TableRow>
-              <TableHead>Nombre</TableHead>
-              <TableHead>Fecha</TableHead>
-              <TableHead></TableHead>
+              <TableCell colSpan={3} className="py-4 text-center">
+                No hay archivos
+              </TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {files.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={3} className="py-4 text-center">
-                  No hay archivos
+          ) : (
+            files.map((f) => (
+              <TableRow key={f.fileId}>
+                <TableCell>
+                  <a href={f.url} target="_blank" rel="noopener noreferrer" className="underline text-primary">
+                    {f.name}
+                  </a>
+                </TableCell>
+                <TableCell>{format(new Date(f.uploadedAt), 'dd/MM/yyyy HH:mm')}</TableCell>
+                <TableCell className="flex gap-2">
+                  <a href={f.url} target="_blank" rel="noopener noreferrer"><Download size={16} /></a>
+                  <button onClick={() => remove(f)} className="cursor-pointer"><Trash size={16} /></button>
                 </TableCell>
               </TableRow>
-            ) : (
-              files.map((f) => (
-                <TableRow key={f.fileId}>
-                  <TableCell>
-                    <a href={f.url} target="_blank" rel="noopener noreferrer" className="underline text-primary">
-                      {f.name}
-                    </a>
-                  </TableCell>
-                  <TableCell>{format(new Date(f.uploadedAt), 'dd/MM/yyyy HH:mm')}</TableCell>
-                  <TableCell className="flex gap-2">
-                    <a href={f.url} target="_blank" rel="noopener noreferrer"><Download size={16} /></a>
-                    <button onClick={() => remove(f)} className="cursor-pointer"><Trash size={16} /></button>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+            ))
+          )}
+        </TableBody>
+      </Table>
     </div>
   )
 }
-
-const DropZone = tw.div`
-  flex flex-col items-center justify-center border-2 border-dashed rounded-md p-4 text-center
-  cursor-pointer text-sm text-muted-foreground hover:bg-muted/40
-`

--- a/src/components/PatientFilesTable.tsx
+++ b/src/components/PatientFilesTable.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useContext, useEffect, useRef, useState } from 'react'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { Upload, Trash, Download } from 'lucide-react'
+import { getPatientFiles, uploadPatientFile, deletePatientFile } from '@/db/patientFiles'
+import { UserContext } from '@/contexts/UserContext'
+import type { PatientFile } from '@/types/db'
+import { toast } from 'sonner'
+import { format } from 'date-fns'
+import tw from 'tailwind-styled-components'
+
+export default function PatientFilesTable({ patientId }: { patientId: string }) {
+  const { tenant, user } = useContext(UserContext)
+  const [files, setFiles] = useState<PatientFile[]>([])
+  const [uploading, setUploading] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (tenant)
+      getPatientFiles(patientId, tenant.tenantId).then(setFiles).catch(() => { })
+  }, [patientId, tenant])
+
+  const handleUpload = async (list: FileList | null) => {
+    if (!list || !tenant || !user) return
+    try {
+      setUploading(true)
+      const results = await Promise.all(
+        Array.from(list).map((f) => uploadPatientFile(patientId, tenant.tenantId, user.uid, f)),
+      )
+      setFiles((prev) => [...prev, ...results])
+      toast.success('Archivo subido')
+    } catch {
+      toast.error('Error al subir archivo')
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    handleUpload(e.dataTransfer.files)
+  }
+
+  const remove = async (file: PatientFile) => {
+    try {
+      await deletePatientFile(file.fileId, file.storagePath)
+      setFiles((prev) => prev.filter((f) => f.fileId !== file.fileId))
+      toast.success('Archivo eliminado')
+    } catch {
+      toast.error('Error al eliminar archivo')
+    }
+  }
+
+  return (
+    <div>
+      <DropZone
+        onDragOver={(e: React.DragEvent<HTMLDivElement>) => e.preventDefault()}
+        onDrop={onDrop}
+        onClick={() => inputRef.current?.click()}
+      >
+        <Upload size={16} />
+        <span>{uploading ? 'Subiendo...' : 'Arrastra archivos o haz click para subir'}</span>
+        <input ref={inputRef} type="file" multiple className="hidden" onChange={(e) => handleUpload(e.target.files)} />
+      </DropZone>
+      <div className="overflow-x-auto mt-4">
+        <Table className="min-w-[500px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Fecha</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {files.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={3} className="py-4 text-center">
+                  No hay archivos
+                </TableCell>
+              </TableRow>
+            ) : (
+              files.map((f) => (
+                <TableRow key={f.fileId}>
+                  <TableCell>
+                    <a href={f.url} target="_blank" rel="noopener noreferrer" className="underline text-primary">
+                      {f.name}
+                    </a>
+                  </TableCell>
+                  <TableCell>{format(new Date(f.uploadedAt), 'dd/MM/yyyy HH:mm')}</TableCell>
+                  <TableCell className="flex gap-2">
+                    <a href={f.url} target="_blank" rel="noopener noreferrer"><Download size={16} /></a>
+                    <button onClick={() => remove(f)} className="cursor-pointer"><Trash size={16} /></button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+const DropZone = tw.div`
+  flex flex-col items-center justify-center border-2 border-dashed rounded-md p-4 text-center
+  cursor-pointer text-sm text-muted-foreground hover:bg-muted/40
+`

--- a/src/components/ProfilePictureModal.tsx
+++ b/src/components/ProfilePictureModal.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import Image from 'next/image';
+import { toast } from 'sonner';
+import { uploadPatientPhoto, deletePatientPhoto } from '@/db/patients';
+import { User2 } from 'lucide-react';
+
+export default function ProfilePictureModal({
+  isOpen,
+  onClose,
+  patient,
+  onPhotoChange,
+  onDeletePhoto,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  patient: { patientId: string; photoUrl?: string; firstName: string; lastName: string };
+  onPhotoChange: (url: string) => void;
+  onDeletePhoto: () => void;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (files: FileList | null) => {
+    if (!files || !files[0]) return;
+    try {
+      setUploading(true);
+      const url = await uploadPatientPhoto(patient.patientId, files[0]);
+      onPhotoChange(url);
+      toast.success('Foto actualizada');
+      onClose();
+    } catch {
+      toast.error('Error al subir foto');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDeletePhoto = async () => {
+    try {
+      setDeleting(true);
+      await deletePatientPhoto(patient.patientId);
+      onDeletePhoto();
+      toast.success('Foto eliminada');
+      onClose();
+    } catch (error: unknown) {
+      console.error('Error deleting photo:', error);
+      // Still clear the photo from UI if the database was updated but storage failed
+      if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string' && error.message.includes('storage/object-not-found')) {
+        onDeletePhoto();
+        toast.success('Foto eliminada (el archivo ya no existía)');
+        onClose();
+      } else {
+        toast.error('Error al eliminar foto');
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Editar Foto de Perfil</DialogTitle>
+        </DialogHeader>
+        
+        <div className="flex flex-col items-center gap-6">
+          {/* Large square image display */}
+          <div className="w-64 h-64 border-2 border-gray-200 rounded-lg overflow-hidden bg-gray-50 flex items-center justify-center">
+            {patient.photoUrl ? (
+              <Image
+                src={patient.photoUrl}
+                alt={`${patient.firstName} ${patient.lastName}`}
+                width={256}
+                height={256}
+                className="w-full h-full object-contain"
+              />
+            ) : (
+              <div className="flex flex-col items-center justify-center text-gray-400">
+                <User2 size={64} className="mb-2" />
+                <span className="text-sm">Sin Foto</span>
+              </div>
+            )}
+          </div>
+          
+          {/* Action buttons */}
+          <div className="flex gap-3 w-full">
+            <Button
+              variant="destructive"
+              onClick={handleDeletePhoto}
+              disabled={deleting || !patient.photoUrl}
+              className="flex-1"
+            >
+              {deleting ? 'Eliminando...' : 'Eliminar Foto'}
+            </Button>
+            <div className="flex-1">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => handleFileChange(e.target.files)}
+              />
+              <Button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="w-full"
+              >
+                {uploading ? 'Subiendo...' : 'Cambiar Foto'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/UploadFileModal.tsx
+++ b/src/components/UploadFileModal.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useContext, useRef, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Upload, FileIcon } from 'lucide-react'
+import { uploadPatientFile } from '@/db/patientFiles'
+import { UserContext } from '@/contexts/UserContext'
+import type { PatientFile } from '@/types/db'
+import { toast } from 'sonner'
+
+export default function UploadFileModal({
+  open,
+  onClose,
+  patientId,
+  onUploaded,
+}: {
+  open: boolean
+  onClose: () => void
+  patientId: string
+  onUploaded: (files: PatientFile[]) => void
+}) {
+  const { tenant, user } = useContext(UserContext)
+  const [uploading, setUploading] = useState(false)
+  const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleFileSelect = (files: FileList | null) => {
+    setSelectedFiles(files)
+  }
+
+  const handleUpload = async () => {
+    if (!selectedFiles || !tenant || !user) return
+    
+    try {
+      setUploading(true)
+      const results = await Promise.all(
+        Array.from(selectedFiles).map((f) => uploadPatientFile(patientId, tenant.tenantId, user.uid, f)),
+      )
+      onUploaded(results)
+      toast.success(`${results.length} archivo(s) subido(s)`)
+      onClose()
+      setSelectedFiles(null)
+    } catch {
+      toast.error('Error al subir archivos')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    handleFileSelect(e.dataTransfer.files)
+  }
+
+  const handleRemoveFile = (index: number) => {
+    if (!selectedFiles) return
+    const newFiles = Array.from(selectedFiles)
+    newFiles.splice(index, 1)
+    const dt = new DataTransfer()
+    newFiles.forEach(file => dt.items.add(file))
+    setSelectedFiles(dt.files.length > 0 ? dt.files : null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Subir Archivos</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-4">
+          {/* Drop zone */}
+          <div
+            className="flex flex-col items-center justify-center border-2 border-dashed rounded-md p-8 text-center cursor-pointer text-sm text-muted-foreground hover:bg-muted/40"
+            onDragOver={(e: React.DragEvent<HTMLDivElement>) => e.preventDefault()}
+            onDrop={onDrop}
+            onClick={() => inputRef.current?.click()}
+          >
+            <Upload size={32} className="mb-2" />
+            <span className="font-medium">Arrastra archivos aquí o haz click para seleccionar</span>
+            <span className="text-xs mt-1">Archivos múltiples permitidos</span>
+            <input 
+              ref={inputRef} 
+              type="file" 
+              multiple 
+              className="hidden" 
+              onChange={(e) => handleFileSelect(e.target.files)} 
+            />
+          </div>
+
+          {/* Selected files list */}
+          {selectedFiles && selectedFiles.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">Archivos seleccionados:</h4>
+              <div className="max-h-32 overflow-y-auto space-y-1">
+                {Array.from(selectedFiles).map((file, index) => (
+                  <div key={index} className="flex items-center justify-between p-2 bg-muted rounded text-xs">
+                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                      <FileIcon size={14} />
+                      <span className="truncate">{file.name}</span>
+                      <span className="text-muted-foreground">({(file.size / 1024 / 1024).toFixed(2)} MB)</span>
+                    </div>
+                    <button 
+                      onClick={() => handleRemoveFile(index)}
+                      className="text-red-500 hover:text-red-700 ml-2"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-2 pt-2">
+            <Button 
+              variant="outline" 
+              onClick={onClose} 
+              className="flex-1"
+              disabled={uploading}
+            >
+              Cancelar
+            </Button>
+            <Button 
+              onClick={handleUpload} 
+              className="flex-1"
+              disabled={uploading || !selectedFiles || selectedFiles.length === 0}
+            >
+              {uploading ? 'Subiendo...' : `Subir ${selectedFiles?.length || 0} archivo(s)`}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/db/notifications.ts
+++ b/src/db/notifications.ts
@@ -16,29 +16,19 @@ import { Notification } from '@/types/db'
 
 export async function getNotifications(userId: string): Promise<Notification[]> {
   try {
-    console.log('🔔 Getting notifications for userId:', userId)
     
     const q = query(collection(db, 'notifications'), where('userId', '==', userId))
     const snap = await getDocs(q)
     
-    console.log('🔔 Basic notifications query result:', {
-      docCount: snap.docs.length,
-      isEmpty: snap.empty
-    })
     
     const notifications = snap.docs.map((d) => {
       const data = d.data()
-      console.log('🔔 Processing basic notification doc:', {
-        id: d.id,
-        data: data
-      })
       return {
         ...(data as Omit<Notification, 'notificationId'>),
         notificationId: d.id,
       }
     }) as Notification[]
     
-    console.log('🔔 Final basic notifications list:', notifications)
     return notifications
   } catch (err) {
     console.error('Error in getNotifications:', err)
@@ -105,12 +95,6 @@ export function listenToNotifications(
     return onSnapshot(q, (snap) => {
       const allNotifications = snap.docs.map((d) => {
         const data = d.data()
-        console.log('🔔 Processing notification doc:', {
-          id: d.id,
-          data: data,
-          archived: data.archived,
-          archivedType: typeof data.archived
-        })
         return {
           ...(data as Omit<Notification, 'notificationId'>),
           notificationId: d.id,
@@ -122,13 +106,6 @@ export function listenToNotifications(
       const filteredNotifications = allNotifications.filter(notification => {
         const isArchived = notification.archived === true
         const shouldShow = targetArchived ? isArchived : !isArchived
-        console.log('🔔 Filtering notification:', {
-          id: notification.notificationId,
-          archived: notification.archived,
-          isArchived,
-          targetArchived,
-          shouldShow
-        })
         return shouldShow
       })
       
@@ -154,13 +131,6 @@ export async function getMoreNotifications(
   },
 ): Promise<{ items: Notification[]; lastDoc: QueryDocumentSnapshot | null }> {
   try {
-    console.log('🔔 Getting more notifications with params:', {
-      userId,
-      tenantId,
-      archived: options.archived ?? false,
-      limit: options.limit ?? 10,
-      startAfterDoc: options.startAfterDoc.id
-    })
     
     // Query without archived filter - we'll filter in code to handle missing field
     const q = query(
@@ -174,19 +144,8 @@ export async function getMoreNotifications(
     // Firestore composite index required for: userId + tenantId + createdAt
     const snap = await getDocs(q)
     
-    console.log('🔔 More notifications query result:', {
-      docCount: snap.docs.length,
-      isEmpty: snap.empty
-    })
-    
     const allNotifications = snap.docs.map((d) => {
       const data = d.data()
-      console.log('🔔 Processing more notification doc:', {
-        id: d.id,
-        data: data,
-        archived: data.archived,
-        archivedType: typeof data.archived
-      })
       return {
         ...(data as Omit<Notification, 'notificationId'>),
         notificationId: d.id,
@@ -198,25 +157,11 @@ export async function getMoreNotifications(
     const filteredNotifications = allNotifications.filter(notification => {
       const isArchived = notification.archived === true
       const shouldShow = targetArchived ? isArchived : !isArchived
-      console.log('🔔 Filtering more notification:', {
-        id: notification.notificationId,
-        archived: notification.archived,
-        isArchived,
-        targetArchived,
-        shouldShow
-      })
       return shouldShow
     })
     
     // Limit the results after filtering
     const limitedNotifications = filteredNotifications.slice(0, options.limit ?? 10)
-    
-    console.log('🔔 More notifications final result:', {
-      total: allNotifications.length,
-      afterFilter: filteredNotifications.length,
-      afterLimit: limitedNotifications.length,
-      notifications: limitedNotifications
-    })
     
     return {
       items: limitedNotifications,

--- a/src/db/patientFiles.ts
+++ b/src/db/patientFiles.ts
@@ -28,7 +28,7 @@ export async function uploadPatientFile(
 ): Promise<PatientFile> {
   try {
     const fileId = doc(collection(db, 'patientFiles')).id
-    const storagePath = `patients/${patientId}/files/${fileId}-${file.name}`
+    const storagePath = `tenants/${tenantId}/patients/${patientId}/files/${fileId}-${file.name}`
     const storageRef = ref(storage, storagePath)
     await uploadBytes(storageRef, file)
     const url = await getDownloadURL(storageRef)

--- a/src/db/patientFiles.ts
+++ b/src/db/patientFiles.ts
@@ -1,0 +1,62 @@
+import { db, storage } from '@/lib/firebase'
+import { collection, query, where, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore'
+import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage'
+import type { PatientFile } from '@/types/db'
+
+export async function getPatientFiles(patientId: string, tenantId?: string): Promise<PatientFile[]> {
+  try {
+    const conditions = [where('patientId', '==', patientId)]
+    if (tenantId) conditions.push(where('tenantId', '==', tenantId))
+    const q = query(collection(db, 'patientFiles'), ...conditions)
+    // If this query requires a composite index, create it in the Firestore console.
+    const snap = await getDocs(q)
+    return snap.docs.map((d) => ({
+      ...(d.data() as Omit<PatientFile, 'fileId'>),
+      fileId: d.id,
+    }))
+  } catch (err) {
+    console.error('Error in getPatientFiles:', err)
+    return []
+  }
+}
+
+export async function uploadPatientFile(
+  patientId: string,
+  tenantId: string,
+  userId: string,
+  file: File,
+): Promise<PatientFile> {
+  try {
+    const fileId = doc(collection(db, 'patientFiles')).id
+    const storagePath = `patients/${patientId}/files/${fileId}-${file.name}`
+    const storageRef = ref(storage, storagePath)
+    await uploadBytes(storageRef, file)
+    const url = await getDownloadURL(storageRef)
+    const now = new Date().toISOString()
+    const data: PatientFile = {
+      tenantId,
+      fileId,
+      patientId,
+      name: file.name,
+      url,
+      storagePath,
+      uploadedAt: now,
+      uploadedBy: userId,
+    }
+    await setDoc(doc(db, 'patientFiles', fileId), data)
+    return data
+  } catch (err) {
+    console.error('Error in uploadPatientFile:', err)
+    throw err
+  }
+}
+
+export async function deletePatientFile(fileId: string, storagePath: string): Promise<void> {
+  try {
+    await deleteDoc(doc(db, 'patientFiles', fileId))
+    await deleteObject(ref(storage, storagePath))
+  } catch (err) {
+    console.error('Error in deletePatientFile:', err)
+    throw err
+  }
+}

--- a/src/db/patients.ts
+++ b/src/db/patients.ts
@@ -84,6 +84,22 @@ export async function deletePatient(id: string): Promise<void> {
   }
 }
 
+export async function uploadPatientPhoto(patientId: string, file: File): Promise<string> {
+  try {
+    const storageRef = ref(storage, `patients/${patientId}/photo`)
+    await uploadBytes(storageRef, file)
+    const url = await getDownloadURL(storageRef)
+    await updateDoc(doc(db, 'patients', patientId), {
+      photoUrl: url,
+      updatedAt: new Date().toISOString(),
+    })
+    return url
+  } catch (err) {
+    console.error('Error in uploadPatientPhoto:', err)
+    throw err
+  }
+}
+
 export async function getMedicalRecords(
   patientId: string,
   tenantId?: string,

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -58,6 +58,8 @@ export type Patient = {
   email?: string
   phone?: string
   address?: string
+  /** URL de la foto del paciente */
+  photoUrl?: string
   /** Alergias registradas */
   allergies?: string
   /** Notas adicionales u observaciones */
@@ -99,6 +101,17 @@ export type MedicalRecord = {
   createdBy: string
   attachments?: MedicalRecordAttachment[]
   appointmentId?: string
+}
+
+export type PatientFile = {
+  tenantId: string
+  fileId: string
+  patientId: string
+  name: string
+  url: string
+  storagePath: string
+  uploadedAt: string
+  uploadedBy: string
 }
 
 export type AppointmentStatus = "scheduled" | "completed" | "cancelled"


### PR DESCRIPTION
## Summary
- allow uploading and displaying patient profile pictures
- support drag-and-drop patient file attachments stored in Firebase
- expose new Firestore helpers for managing patient files

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689162eeeecc8333aaab766125b971e4