### PR TITLE
fix: improve auth flows

### DIFF
--- a/src/lib/magic-link.ts
+++ b/src/lib/magic-link.ts
@@ -11,13 +11,12 @@ const getBaseUrl = () => {
     : 'http://localhost:3000'
 }
 
-const actionCodeSettings = {
-  url: `${getBaseUrl()}/finishSignIn`,
-  handleCodeInApp: true,
-}
-
 export async function sendMagicLink(email: string): Promise<void> {
   try {
+    const actionCodeSettings = {
+      url: `${getBaseUrl()}/finishSignIn?email=${encodeURIComponent(email)}`,
+      handleCodeInApp: true,
+    }
     await sendSignInLinkToEmail(auth, email, actionCodeSettings)
     // Guardar el email en localStorage para recuperarlo después
     window.localStorage.setItem('emailForSignIn', email)
@@ -36,9 +35,13 @@ export async function completeMagicLinkSignIn(): Promise<void> {
     throw new Error('No magic link found in URL')
   }
 
-  const email = window.localStorage.getItem('emailForSignIn')
+  const storedEmail = window.localStorage.getItem('emailForSignIn')
+  const url = new URL(window.location.href)
+  const emailParam = url.searchParams.get('email')
+  const email = storedEmail || emailParam
+
   if (!email) {
-    throw new Error('Email not found in localStorage')
+    throw new Error('Email not found for sign in')
   }
 
   try {


### PR DESCRIPTION
## Summary
- preserve email in magic link URLs and recover it on sign-in to fix mobile login
- refine password login to only try invitations when user doesn't exist and handle wrong passwords

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68917d012c4083339039557cfc96c706