### PR TITLE
feat: add dashboard onboarding tutorial

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -28,6 +28,7 @@ import MobileHomeDashboard from '@/components/MobileHomeDashboard'
 import type { Patient, Appointment } from '@/types/db'
 import { toast } from 'sonner'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import DashboardTutorial from '@/components/DashboardTutorial'
 
 const locales = { es }
 const localizer = dateFnsLocalizer({
@@ -138,6 +139,9 @@ export default function DashboardCalendar() {
     <>
       {/* Mobile Home Dashboard */}
       <MobileHomeDashboard />
+
+      {/* Onboarding Tutorial */}
+      <DashboardTutorial />
 
       {/* Desktop Calendar View */}
       <DesktopWrapper>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -152,3 +152,10 @@
 .rbc-day-slot .rbc-today {
   background-color: rgba(58, 189, 212, 0.15); /* versión dimmed del primary */
 }
+
+.tutorial-highlight {
+  box-shadow: 0 0 0 3px var(--primary);
+  border-radius: 0.5rem;
+  position: relative;
+  z-index: 50;
+}

--- a/src/components/DashboardTutorial.tsx
+++ b/src/components/DashboardTutorial.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import tw from 'tailwind-styled-components'
+
+interface Step {
+  selector: string
+  content: string
+}
+
+const Overlay = tw.div`fixed inset-0 bg-black/50 z-40`
+const Tooltip = tw.div`absolute bg-background text-foreground border border-border rounded-lg shadow-lg p-4 w-64 z-50`
+const Actions = tw.div`mt-4 flex justify-end gap-2`
+
+export default function DashboardTutorial() {
+  const steps: Step[] = useMemo(
+    () => [
+      { selector: '[data-tour="nav-dashboard"]', content: 'Aquí puedes ver tu calendario de citas.' },
+      { selector: '[data-tour="nav-patients"]', content: 'Gestiona tus pacientes desde aquí.' },
+      { selector: '[data-tour="nav-notifications"]', content: 'Consulta tus notificaciones.' },
+      { selector: '[data-tour="nav-reports"]', content: 'Genera y revisa reportes.' },
+      { selector: '[data-tour="nav-settings"]', content: 'Configura la aplicación a tu gusto.' },
+      { selector: '[data-tour="user-card"]', content: 'Accede a la configuración de tu cuenta.' },
+    ],
+    [],
+  )
+
+  const [step, setStep] = useState<number>(-1)
+  const [pos, setPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
+
+  useEffect(() => {
+    try {
+      const seen = window.localStorage.getItem('dashboardTutorialSeen')
+      const isDesktop = window.innerWidth >= 768
+      if (!seen && isDesktop) {
+        setStep(0)
+      }
+    } catch (err) {
+      console.error('Error initializing dashboard tutorial:', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (step < 0 || step >= steps.length) return
+    const current = steps[step]
+    const el = document.querySelector(current.selector) as HTMLElement | null
+    if (!el) return
+    el.classList.add('tutorial-highlight')
+    const rect = el.getBoundingClientRect()
+    setPos({ top: rect.bottom + 8, left: rect.left })
+    return () => {
+      el.classList.remove('tutorial-highlight')
+    }
+  }, [step, steps])
+
+  const finish = () => {
+    try {
+      window.localStorage.setItem('dashboardTutorialSeen', 'true')
+    } catch (err) {
+      console.error('Error saving dashboard tutorial state:', err)
+    }
+    setStep(-1)
+  }
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep((s) => s + 1)
+    } else {
+      finish()
+    }
+  }
+
+  const skip = () => finish()
+
+  if (step < 0 || step >= steps.length) return null
+
+  return (
+    <>
+      <Overlay onClick={skip} />
+      <Tooltip style={{ top: pos.top, left: pos.left }}>
+        <p>{steps[step].content}</p>
+        <Actions>
+          <Button variant="secondary" size="sm" onClick={skip} type="button">
+            Omitir
+          </Button>
+          <Button size="sm" onClick={next} type="button">
+            {step === steps.length - 1 ? 'Finalizar' : 'Siguiente'}
+          </Button>
+        </Actions>
+      </Tooltip>
+    </>
+  )
+}
+

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,11 +20,11 @@ import { UserContext } from '@/contexts/UserContext'
 import { listenToNotifications } from '@/db/notifications'
 
 const navItems = [
-  { href: '/dashboard', label: 'Calendario', icon: Calendar },
-  { href: '/patients', label: 'Pacientes', icon: Users },
-  { href: '/notifications', label: 'Notificaciones', icon: Bell },
-  { href: '/reports', label: 'Reportes', icon: BarChart3 },
-  { href: '/settings', label: 'Ajustes', icon: Settings },
+  { href: '/dashboard', label: 'Calendario', icon: Calendar, tourId: 'nav-dashboard' },
+  { href: '/patients', label: 'Pacientes', icon: Users, tourId: 'nav-patients' },
+  { href: '/notifications', label: 'Notificaciones', icon: Bell, tourId: 'nav-notifications' },
+  { href: '/reports', label: 'Reportes', icon: BarChart3, tourId: 'nav-reports' },
+  { href: '/settings', label: 'Ajustes', icon: Settings, tourId: 'nav-settings' },
 ]
 
 interface SidebarProps {
@@ -84,10 +84,11 @@ export default function Sidebar({ collapsed = false, onCollapsedChange }: Sideba
         )}
 
         <NavList>
-          {navItems.map(({ href, label, icon: Icon }) => (
+        {navItems.map(({ href, label, icon: Icon, tourId }) => (
             <NavItem key={href} $active={pathname === href} $collapsed={collapsed}>
               <Link
                 href={href}
+                data-tour={tourId}
                 className={`flex items-center gap-2 w-full relative ${collapsed ? 'justify-center px-2 py-3' : 'px-4 py-3 '}`}
               >
                 <div className="flex items-center gap-2 w-full justify-center">

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -50,7 +50,7 @@ export default function UserSettings({ collapsed }: { collapsed: boolean }) {
 
   return (
     <>
-      <CardWrapper onClick={() => setOpen(true)}>
+      <CardWrapper data-tour="user-card" onClick={() => setOpen(true)}>
         {collapsed ? (
           <CollapsedCard>
             <UserIcon size={20} />


### PR DESCRIPTION
## Summary
- guide desktop users through sidebar features with an onboarding tutorial
- tag sidebar and user card elements for tutorial steps
- style highlighted elements for clarity

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892acd464a48333989a36b554240eee